### PR TITLE
Multi action context

### DIFF
--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -15,13 +15,137 @@
 #include <lager/deps.hpp>
 #include <lager/util.hpp>
 
+#include <boost/hana/find_if.hpp>
+#include <boost/hana/type.hpp>
+
 #include <functional>
+#include <type_traits>
 
 namespace lager {
 
 //!
+// Type used to declare contexes suporting multiple action types.
+//
+// @see context
+//
+template <typename... Actions>
+struct actions
+{};
+
+//!
+// Metafunction that wraps the parameter in `actions<T>` if it is not wrapped
+// already, this is, it returns @a ActionOrActions if it is a type of the form
+// `actions<Ts...>` or `actions<ActionOrActions>` otherwise.
+//
+template <typename ActionOrActions>
+struct as_actions
+{
+    using type = actions<ActionOrActions>;
+};
+
+template <typename... Actions>
+struct as_actions<actions<Actions...>>
+{
+    using type = actions<Actions...>;
+};
+
+template <typename ActionOrActions>
+using as_actions_t = typename as_actions<ActionOrActions>::type;
+
+namespace detail {
+
+template <typename Action, typename Candidates>
+auto find_convertible_action_aux(Action act, Candidates candidates)
+{
+    auto is_convertible = [](auto t) {
+        return std::is_convertible<typename Action::type,
+                                   typename decltype(t)::type>{};
+    };
+    return boost::hana::find_if(candidates, is_convertible).value();
+}
+
+template <typename Action, typename... Actions>
+using find_convertible_action_t = typename decltype(find_convertible_action_aux(
+    boost::hana::type_c<Action>, boost::hana::tuple_t<Actions...>))::type;
+
+template <typename... Actions>
+struct dispatcher;
+
+template <typename... Actions>
+struct dispatcher<actions<Actions...>> : std::function<void(Actions)>...
+{
+    using std::function<void(Actions)>::operator()...;
+
+    dispatcher() = default;
+
+    template <typename... As>
+    dispatcher(dispatcher<actions<As...>> other)
+        : std::function<void(Actions)>{static_cast<
+              std::function<void(find_convertible_action_t<Actions, As...>)>&>(
+              other)}...
+    {}
+
+    template <typename Fn>
+    dispatcher(Fn other)
+        : std::function<void(Actions)>{std::move(other)}...
+    {}
+};
+
+struct event_loop_iface
+{
+    virtual ~event_loop_iface()               = default;
+    virtual void async(std::function<void()>) = 0;
+    virtual void finish()                     = 0;
+    virtual void pause()                      = 0;
+    virtual void resume()                     = 0;
+};
+
+template <typename EventLoop>
+struct event_loop_impl final : event_loop_iface
+{
+    EventLoop& loop;
+
+    event_loop_impl(EventLoop& loop_)
+        : loop{loop_}
+    {}
+    void async(std::function<void()> fn) override { loop.async(std::move(fn)); }
+    void finish() override { loop.finish(); }
+    void pause() override { loop.pause(); }
+    void resume() override { loop.resume(); }
+};
+
+} // namespace detail
+
+//!
 // Provide some _context_ for effectful functions, allowing them to control the
 // event loop and dispatch new actions into the store.
+//
+// A context is convertible to support "more restricted" actions.  This is, if
+// action `B` is convertible to action `A`, `context<A>` is convertible to
+// `context<B>`, in this sense, contexes are contravariant to the action type.
+// One can also specify multiple action types by using `action<>` tag. This is
+// useful to subset actions from a variant, here is an example:
+//
+// @code
+//      struct action_A {};
+//      struct action_B {};
+//      struct action_C {};
+//      using any_action = std::variant<action_A, action_B, action_C>>;
+//
+//      void some_effect(context<actions<action_A, action_B>> ctx)
+//      {
+//          if (...)
+//              ctx.dispatch(action_A{});
+//          else
+//              ctx.dispatch(action_B{});
+//      }
+//
+//     void other_effect(context<any_action> ctx)
+//     {
+//         some_effect(ctx);
+//         ...
+//     }
+// @endcode
 //
 // @note This is a reference type and it's life-time is bound to the associated
 //       store.  It is invalid to use it after the store has been destructed.
@@ -29,46 +153,45 @@ namespace lager {
 //
 // @todo Make constructors private.
 //
-template <typename Action, typename Deps = lager::deps<>>
+template <typename Actions, typename Deps = lager::deps<>>
 struct context : Deps
 {
-    using deps_t     = Deps;
-    using action_t   = Action;
-    using command_t  = std::function<void()>;
-    using dispatch_t = std::function<void(action_t)>;
-    using async_t    = std::function<void(std::function<void()>)>;
-
-    dispatch_t dispatch;
-    async_t async;
-    command_t finish;
-    command_t pause;
-    command_t resume;
+    using deps_t    = Deps;
+    using actions_t = as_actions_t<Actions>;
 
     context() = default;
 
-    template <typename Action_, typename Deps_>
-    context(const context<Action_, Deps_>& ctx)
+    template <typename Actions_, typename Deps_>
+    context(const context<Actions_, Deps_>& ctx)
         : deps_t{ctx}
-        , dispatch{ctx.dispatch}
-        , async{ctx.async}
-        , finish{ctx.finish}
-        , pause{ctx.pause}
-        , resume{ctx.resume}
+        , dispatcher_{ctx.dispatcher_}
+        , loop_{ctx.loop_}
     {}
 
-    context(dispatch_t dispatch_,
-            async_t async_,
-            command_t finish_,
-            command_t pause_,
-            command_t resume_,
-            deps_t deps_)
-        : deps_t{std::move(deps_)}
-        , dispatch{std::move(dispatch_)}
-        , async{std::move(async_)}
-        , finish{std::move(finish_)}
-        , pause{std::move(pause_)}
-        , resume{std::move(resume_)}
+    template <typename Dispatcher, typename EventLoop>
+    context(Dispatcher dispatcher, EventLoop& loop, deps_t deps)
+        : deps_t{std::move(deps)}
+        , dispatcher_{std::move(dispatcher)}
+        , loop_{std::make_shared<detail::event_loop_impl<EventLoop>>(loop)}
     {}
+
+    template <typename Action>
+    void dispatch(Action&& act) const
+    {
+        dispatcher_(std::forward<Action>(act));
+    }
+
+    void async(std::function<void()> fn) const { loop_->async(std::move(fn)); }
+    void finish() const { loop_->finish(); }
+    void pause() const { loop_->pause(); }
+    void resume() const { loop_->resume(); }
+
+private:
+    template <typename A, typename Ds>
+    friend struct context;
+
+    detail::dispatcher<actions_t> dispatcher_;
+    std::shared_ptr<detail::event_loop_iface> loop_;
 };
 
 //!

--- a/lager/store.hpp
+++ b/lager/store.hpp
@@ -113,10 +113,10 @@ private:
         using deps_t             = Deps;
         using concrete_context_t = context<Action, Deps>;
 
-        concrete_context_t ctx;
         event_loop_t loop;
         reducer_t reducer;
         view_t view;
+        concrete_context_t ctx;
 
         impl(model_t init_,
              reducer_t reducer_,
@@ -124,18 +124,15 @@ private:
              event_loop_t loop_,
              deps_t deps_)
             : impl_base{std::move(init_)}
-            , ctx{[this](auto ev) { dispatch(ev); },
-                  [this](auto fn) { loop.async(fn); },
-                  [this] { loop.finish(); },
-                  [this] { loop.pause(); },
-                  [this] { loop.resume(); },
-                  std::move(deps_)}
             , loop{std::move(loop_)}
             , reducer{std::move(reducer_)}
             , view{std::move(view_)}
+            , ctx{[this](auto&& act) { dispatch(LAGER_FWD(act)); },
+                  loop,
+                  std::move(deps_)}
         {
             update();
-        };
+        }
 
         void update() override
         {


### PR DESCRIPTION
This PR adds support for the `context` (and as such, also `effect`) to spuport multiple different action types. This can be specified with the `lager::actions<...>` tag. These can be multiple types that are convertible from the parent action type, usually a form of variant. Note that the store still can only have a single action type.
 
```cpp
    struct action_A {};
    struct action_B {};
    struct action_C {};
    using any_action = std::variant<action_A, action_B, action_C>>;

    void some_effect(lager::context<lager::actions<action_A, action_B>> ctx)
    {
        if (...)
            ctx.dispatch(action_A{});
        else
            ctx.dispatch(action_B{});
    }

    void other_effect(context<any_action> ctx)
    {
        some_effect(ctx);
        ...
    }
```