### PR TITLE
add cmake configure step in readme for header only usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,13 +125,19 @@ may have other dependencies documented in their respective sections.
 Usage
 -----
 
-This is a **header only** library.  You can just copy the ``lager``
+This is a **header only** library but to be configured correctly you need
+to run `CMake`_ first::
+
+    mkdir -p build && cd build
+    cmake .. -D lager_BUILD_DEBUGGER=OFF -D lager_BUILD_TESTS=OFF -D lager_BUILD_EXAMPLES=OFF -D lager_BUILD_DOCS=OFF
+
+Now you can just copy the ``lager``
 subfolder somewhere in your *include path*.
 
 Some components, like the time-travelling debugger, also require the
 installation of extra files.
 
-Alternatively, you can use `CMake`_ to install the library in your
+You can use `CMake`_ to install the library in your
 system once you have manually cloned the repository::
 
     mkdir -p build && cd build


### PR DESCRIPTION
When I tried to use this library as header only it did not compile. The file config.hpp was missing. I figured out that if I run cmake as describe in the commit the according file got generated. So I thouhgt this should be reflected in the documentation.
If there is any other way to get the config.hpp generated please let me know.