### PR TITLE
add missing includes to deps.hpp and event_loop/sdl.hpp

### DIFF
--- a/lager/deps.hpp
+++ b/lager/deps.hpp
@@ -24,6 +24,7 @@
 
 #include <functional>
 #include <optional>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 

--- a/lager/event_loop/sdl.hpp
+++ b/lager/event_loop/sdl.hpp
@@ -14,6 +14,7 @@
 
 #include <SDL.h>
 
+#include <algorithm>
 #include <atomic>
 #include <functional>
 


### PR DESCRIPTION
`deps.hpp` uses [`std::runtime_error`](https://en.cppreference.com/w/cpp/error/runtime_error) which is defined in `<stdexcept>`,

and `sdl.hpp` uses [`std::min`](https://en.cppreference.com/w/cpp/algorithm/min) which is defined in `<algorithm>`.

Both should be explicitly imported.