### PR TITLE
Redux cursors

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -277,10 +277,17 @@ purposes now:
 
 .. code-block:: c++
 
-   void draw(const model& c)
-   {
-       std::cout << "current value: " << c.value << '\n';
-   }
+    void draw(counter::model prev, counter::model curr)
+    {
+        std::cout << "last value: " << prev.value << '\n';
+        std::cout << "current value: " << curr.value << '\n';
+    }
+
+.. tip:: The view function has access to both the last and new value
+         of the application.  This allows the view to decide which
+         parts of the view do need to be updated based on the
+         differences between the old and new models.
+
 
 Glueing things together
 -----------------------
@@ -305,12 +312,11 @@ The store
 
 The main component provided by the library is the
 :cpp:class:`lager::store`.  You make one by providing an action type,
-the initial model state, the reducer, the draw function, and the event
-loop interface.  The *store* will then provide a thread-safe
-:cpp:func:`dispatch() <lager::store::dispatch>` method that can be
-used to inject actions in the system.  Whenever it receives an action,
-it will evaluate the *reducer* in the event-loop to update the state,
-and trigger a redraw.
+the initial model state, the reducer, the event loop interface.  The
+*store* will then provide a thread-safe :cpp:func:`dispatch()
+<lager::store::dispatch>` method that can be used to inject actions in
+the system.  Whenever it receives an action, it will evaluate the
+*reducer* in the event-loop to update the state, and trigger a redraw.
 
 Main loop
 ~~~~~~~~~
@@ -325,8 +331,8 @@ procedure of our application:
        auto store = lager::make_store<counter::action>(
            model{},
            update,
-           draw,
            lager::with_manual_event_loop{});
+       watch(store, draw);
 
        auto event = char{};
        while (std::cin >> event) {

--- a/doc/cursors.rst
+++ b/doc/cursors.rst
@@ -1,0 +1,10 @@
+
+.. _cursors:
+
+Cursors
+=======
+
+.. admonition:: TODO
+   :class: danger
+
+   This section of the documentation has not been written yet.

--- a/doc/modularity.rst
+++ b/doc/modularity.rst
@@ -355,8 +355,7 @@ that uses it, enhanced with the ``history`` functionality:
 
    auto store = lager::make_store<history_action<doc_action>>(
        history_model<doc_model>{},
-       [] (auto m, auto a) { return update_history(update_doc, m, a); },
-       draw_doc);
+       [] (auto m, auto a) { return update_history(update_doc, m, a); });
 
 It would be nice, however, if we could write instead:
 
@@ -366,7 +365,6 @@ It would be nice, however, if we could write instead:
    auto store = lager::make_store<doc_action>(
        doc_model,
        update_doc,
-       draw_doc,
        with_history);
 
 We can indeed write such a ``with_history`` construction, my using the
@@ -388,7 +386,6 @@ follows:
        return [] (auto action,
                   auto model,
                   auto reducer,
-                  auto view,
                   auto loop,
                   auto deps)
        {
@@ -399,7 +396,6 @@ follows:
                lager::type_<history_action<action_t>>,
                history_model<model_t>{model},
                [reducer](auto m, auto a) { return update_history(reducer, m, a); },
-               view,
                loop,
                deps);
        };

--- a/doc/views.rst
+++ b/doc/views.rst
@@ -4,8 +4,8 @@
 Views
 =====
 
-After the data-model is updated via a :ref:`Reducer<reducers>`, the
-view procedure provided to the store is invoked to update the UI.
+After the data-model is updated via a :ref:`Reducer<reducers>`, all
+views connected with the :cpp:func:`lager::watch` function are called.
 There are various ways to implement a view in the Lager model.
 
 Value based UI

--- a/example/autopong/main.cpp
+++ b/example/autopong/main.cpp
@@ -306,7 +306,6 @@ int main(int argc, const char** argv)
     auto loop  = lager::sdl_event_loop{};
     auto store = lager::make_store<action>(game{},
                                            update,
-                                           std::bind(draw, view, _1),
                                            lager::with_sdl_event_loop{loop},
 #ifdef DEBUGGER
                                            lager::with_debugger(debugger)
@@ -314,7 +313,7 @@ int main(int argc, const char** argv)
                                            lager::identity
 #endif
     );
-
+    watch(store, [&](auto&&, auto&& val) { draw(view, LAGER_FWD(val)); });
     loop.run(
         [&](const SDL_Event& ev) {
             if (auto act = intent(ev))

--- a/example/counter/ncurses/main.cpp
+++ b/example/counter/ncurses/main.cpp
@@ -67,7 +67,6 @@ int main(int argc, const char** argv)
     auto store = lager::make_store<counter::action>(
         counter::model{},
         counter::update,
-        draw,
         lager::with_boost_asio_event_loop{serv},
         lager::comp(
 #ifdef DEBUGGER
@@ -80,6 +79,8 @@ int main(int argc, const char** argv)
             lager::with_debugger(meta_debugger),
 #endif
             lager::identity));
+
+    watch(store, [](auto&&, auto&& val) { draw(unwrap(val)); });
 
     term.start([&](auto ev) {
         std::visit(
@@ -96,7 +97,7 @@ int main(int argc, const char** argv)
                              ev.key == ncurses::key_code{OK, '[' - '@'}) // esc
                         term.stop();
                 },
-                [&](ncurses::resize_event) { store.update(); }},
+                [&](ncurses::resize_event) { draw(unwrap(store.get())); }},
             ev);
     });
 

--- a/example/counter/ncurses/main.cpp
+++ b/example/counter/ncurses/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, const char** argv)
             lager::identity));
 
     watch(store, [](auto&&, auto&& val) { draw(unwrap(val)); });
+    draw(unwrap(store.get()));
 
     term.start([&](auto ev) {
         std::visit(

--- a/example/counter/sdl2/main.cpp
+++ b/example/counter/sdl2/main.cpp
@@ -96,6 +96,7 @@ int main()
         counter::model{}, counter::update, lager::with_sdl_event_loop{loop});
 
     watch(store, [&](auto&&, auto&& val) { draw(view, val); });
+    draw(view, store.get());
 
     loop.run([&](const SDL_Event& ev) {
         if (auto act = intent(ev))

--- a/example/counter/sdl2/main.cpp
+++ b/example/counter/sdl2/main.cpp
@@ -90,13 +90,12 @@ int main()
     SDL_Init(SDL_INIT_VIDEO);
     TTF_Init();
 
-    auto view = sdl_view{};
-    auto loop = lager::sdl_event_loop{};
-    auto store =
-        lager::make_store<counter::action>(counter::model{},
-                                           counter::update,
-                                           std::bind(draw, view, _1),
-                                           lager::with_sdl_event_loop{loop});
+    auto view  = sdl_view{};
+    auto loop  = lager::sdl_event_loop{};
+    auto store = lager::make_store<counter::action>(
+        counter::model{}, counter::update, lager::with_sdl_event_loop{loop});
+
+    watch(store, [&](auto&&, auto&& val) { draw(view, val); });
 
     loop.run([&](const SDL_Event& ev) {
         if (auto act = intent(ev))

--- a/example/counter/std/main.cpp
+++ b/example/counter/std/main.cpp
@@ -15,9 +15,10 @@
 #include <lager/event_loop/manual.hpp>
 #include <lager/store.hpp>
 
-void draw(counter::model c)
+void draw(counter::model prev, counter::model curr)
 {
-    std::cout << "current value: " << c.value << '\n';
+    std::cout << "last value: " << prev.value << '\n';
+    std::cout << "current value: " << curr.value << '\n';
 }
 
 std::optional<counter::action> intent(char event)
@@ -36,11 +37,9 @@ std::optional<counter::action> intent(char event)
 
 int main()
 {
-    auto store =
-        lager::make_store<counter::action>(counter::model{},
-                                           counter::update,
-                                           draw,
-                                           lager::with_manual_event_loop{});
+    auto store = lager::make_store<counter::action>(
+        counter::model{}, counter::update, lager::with_manual_event_loop{});
+    watch(store, draw);
 
     auto event = char{};
     while (std::cin >> event) {

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -288,8 +288,8 @@ constexpr auto has_effect_v = has_effect<Reducer, Model, Action, Deps>::value;
 //! @{
 
 /*!
- * Invokes the @a reducer with the @a model and @a action and stores the result
- * in the given model. If the reducer returns an effect, it evaluates the @a
+ * Invokes the @a reducer with the @a model and @a action and returns the
+ * resulting model. If the reducer returns an effect, it evaluates the @a
  * handler passing the effect to it. This function can be used to generically
  * handle both reducers with or without side-effects.
  *
@@ -301,15 +301,15 @@ template <typename Deps = lager::deps<>,
           typename Action,
           typename EffectHandler,
           std::enable_if_t<has_effect_v<Reducer, Model, Action, Deps>, int> = 0>
-void invoke_reducer(Reducer&& reducer,
-                    Model& model,
+auto invoke_reducer(Reducer&& reducer,
+                    Model&& model,
                     Action&& action,
-                    EffectHandler&& handler)
+                    EffectHandler&& handler) -> std::decay_t<Model>
 {
     auto [new_model, effect] =
-        std::invoke(LAGER_FWD(reducer), std::move(model), LAGER_FWD(action));
-    model = std::move(new_model);
+        std::invoke(LAGER_FWD(reducer), LAGER_FWD(model), LAGER_FWD(action));
     LAGER_FWD(handler)(effect);
+    return std::move(new_model);
 }
 
 template <
@@ -319,13 +319,12 @@ template <
     typename Action,
     typename EffectHandler,
     std::enable_if_t<!has_effect_v<Reducer, Model, Action, Deps>, int> = 0>
-void invoke_reducer(Reducer&& reducer,
-                    Model& model,
+auto invoke_reducer(Reducer&& reducer,
+                    Model&& model,
                     Action&& action,
-                    EffectHandler&&)
+                    EffectHandler &&) -> std::decay_t<Model>
 {
-    model =
-        std::invoke(LAGER_FWD(reducer), std::move(model), LAGER_FWD(action));
+    return std::invoke(LAGER_FWD(reducer), LAGER_FWD(model), LAGER_FWD(action));
 }
 
 /*!

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -232,10 +232,7 @@ struct context : Deps
         dispatcher_(std::forward<Action>(act));
     }
 
-    void async(std::function<void()> fn) const { loop_->async(std::move(fn)); }
-    void finish() const { loop_->finish(); }
-    void pause() const { loop_->pause(); }
-    void resume() const { loop_->resume(); }
+    detail::event_loop_iface& loop() const { return *loop_; }
 
 private:
     template <typename A, typename Ds>

--- a/lager/debug/debugger.hpp
+++ b/lager/debug/debugger.hpp
@@ -138,11 +138,11 @@ struct debugger
                 },
                 [&](pause_action) -> result_t {
                     m.paused = true;
-                    return {m, [](auto&& ctx) { ctx.pause(); }};
+                    return {m, [](auto&& ctx) { ctx.loop().pause(); }};
                 },
                 [&](resume_action) -> result_t {
                     auto resume_eff =
-                        effect<action>{[](auto&& ctx) { ctx.resume(); }};
+                        effect<action>{[](auto&& ctx) { ctx.loop().resume(); }};
                     auto eff         = effect<action, deps_t>{noop};
                     auto pending     = m.pending;
                     m.paused         = false;

--- a/lager/debug/tree_debugger.hpp
+++ b/lager/debug/tree_debugger.hpp
@@ -207,6 +207,11 @@ struct tree_debugger
         summary_t summary() const { return do_summary(branches); }
 
         operator const Model&() const { return lookup(cursor).second; }
+
+        friend decltype(auto) unwrap(const model& m)
+        {
+            return unwrap(static_cast<const Model&>(m));
+        }
     };
 
     using result_t = std::pair<model, effect<action, deps_t>>;
@@ -222,9 +227,8 @@ struct tree_debugger
                         return {m, noop};
                     } else {
                         auto eff   = effect<action, deps_t>{noop};
-                        auto state = static_cast<base_model>(m);
-                        invoke_reducer<deps_t>(
-                            reducer, state, act, [&](auto&& e) {
+                        auto state = invoke_reducer<deps_t>(
+                            reducer, m, act, [&](auto&& e) {
                                 eff = LAGER_FWD(e);
                             });
                         m.append(act, state);
@@ -277,11 +281,10 @@ struct tree_debugger
             act);
     }
 
-    template <typename Server, typename ViewFn>
-    static void view(Server& serv, ViewFn&& view, const model& m)
+    template <typename Server>
+    static void view(Server& serv, const model& m)
     {
         serv.view(m);
-        std::forward<ViewFn>(view)(m);
     }
 
     LAGER_CEREAL_NESTED_STRUCT(undo_action);

--- a/lager/debug/tree_debugger.hpp
+++ b/lager/debug/tree_debugger.hpp
@@ -257,11 +257,11 @@ struct tree_debugger
                 },
                 [&](pause_action) -> result_t {
                     m.paused = true;
-                    return {m, [](auto&& ctx) { ctx.pause(); }};
+                    return {m, [](auto&& ctx) { ctx.loop().pause(); }};
                 },
                 [&](resume_action) -> result_t {
                     auto resume_eff =
-                        effect<action>{[](auto&& ctx) { ctx.resume(); }};
+                        effect<action>{[](auto&& ctx) { ctx.loop().resume(); }};
                     auto eff         = effect<action>{noop};
                     auto pending     = m.pending;
                     m.paused         = false;

--- a/lager/deps.hpp
+++ b/lager/deps.hpp
@@ -410,7 +410,7 @@ public:
 
 private:
     template <typename... Ds>
-    friend struct deps;
+    friend class deps;
 
     using storage_t = boost::hana::map<
         boost::hana::pair<get_key_t<Deps>, get_storage_t<Deps>>...>;

--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -84,6 +84,18 @@ struct writer_node_base
     virtual void send_up(T&&)      = 0;
 };
 
+template <typename T>
+auto has_changed(T&& a, T&& b) -> decltype(!(a == b))
+{
+    return !(a == b);
+}
+
+template <typename T>
+auto has_changed(const T& a, const T& b)
+{
+    return true;
+}
+
 /*!
  * Base class for the various node types.  Provides basic
  * functionality for setting values and propagating them to children.
@@ -110,6 +122,7 @@ public:
     virtual void recompute() {}
     virtual void recompute_deep() {}
 
+    value_type& current() { return current_; }
     const value_type& current() const { return current_; }
     const value_type& last() const { return last_; }
 
@@ -127,7 +140,7 @@ public:
     template <typename U>
     void push_down(U&& value)
     {
-        if (value != current_) {
+        if (has_changed(value, current_)) {
             current_         = std::forward<U>(value);
             needs_send_down_ = true;
         }

--- a/lager/event_loop/manual.hpp
+++ b/lager/event_loop/manual.hpp
@@ -31,8 +31,10 @@ struct with_manual_event_loop
         auto is_root = queue_.empty();
         queue_.push_back(std::forward<Fn>(fn));
         if (is_root) {
-            for (auto i = std::size_t{}; i < queue_.size(); ++i)
-                queue_[i]();
+            for (auto i = std::size_t{}; i < queue_.size(); ++i) {
+                auto f = std::move(queue_[i]);
+                f();
+            }
             queue_.clear();
         }
     }

--- a/lager/reader.hpp
+++ b/lager/reader.hpp
@@ -30,6 +30,8 @@ template <typename DerivT>
 struct reader_mixin
 {
     decltype(auto) get() const { return node()->last(); }
+    decltype(auto) operator*() const { return get(); }
+    decltype(auto) operator-> () const { return &get(); }
 
     template <typename T>
     auto operator[](T&& t) const

--- a/lager/util.hpp
+++ b/lager/util.hpp
@@ -124,6 +124,15 @@ auto comp(Fn&& f, Fns&&... fns)
     return result_t{std::forward<Fn>(f), comp(std::forward<Fns>(fns)...)};
 }
 
+/*!
+ * Unwraps multiple layers of state wrappers added by store enhancers.
+ */
+template <typename T>
+const T& unwrap(const T& x)
+{
+    return x;
+}
+
 //! @} group: util
 
 inline const char* resources_path()


### PR DESCRIPTION
This makes the `lager::store` be a `reader` kind of cursor. This simplifies the API: we do not need a view function, we can just `watch` the store itself. Also, we get some niceties, since watching a cursor is more versatile (we also get the previous value) and of course, we can use derived cursors to provide views for sub-sections of the model, etc.

It is an open question whether it would be interesting to make it also a `writer` kind of cursor. This could be added with a `with_writeable()` enhancer that adds a `lager::replace_state_action` (it is dispatched on `set()`) and somewhat makes the store a full cursor. Note that we need the action to avoid problems wrt. time-travelling debugging. Anyways, this may present conceptual problems and add too much temptation to just avoid actions, so maybe we shall avoid it altogether.

FYI @CJBussey 