### PR TITLE
Bugfix/example dont reseed generator

### DIFF
--- a/example/snake/qml/main.cpp
+++ b/example/snake/qml/main.cpp
@@ -20,7 +20,6 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 
-#include <cmath>
 #include <random>
 #include <utility>
 


### PR DESCRIPTION
While playing around with the Snake game, I noticed that the randomness of the apple position on subsequent restarts of the game was off. I noticed this was down to the funky seeding I was doing when restarting. Now when `reset` is called, we only update the game state.