### PR TITLE
Fix typos in online docs (model.rst)

### DIFF
--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -185,7 +185,7 @@ In the previous example, there is ony one instance of
 ``boost::asio::io_context`` that is passed to all the effects that are
 evaluated within the Lager context.  This is a good replacement of the
 `singleton design pattern`_: there is a single instance, but there is
-low phisical coupling and you can still replace the instance in a
+low physical coupling and you can still replace the instance in a
 different context, particularly in unit tests.
 
 .. _singleton design pattern: https://en.wikipedia.org/wiki/Singleton_pattern

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -203,7 +203,7 @@ progresses in one direction, that change is an implicit construction,
 that entities can not be dealt with concurrently.  Identity becomes an
 implicit and flaky construction.
 
-However, in real life, we deal with identity explicit way.  That is
+However, in real life, we deal with identity in an explicit way.  That is
 why people have *names* or *passport numbers*.  These are special
 values, **identity values**, that help us identify people. Identity as
 such serves a double purpose, solving the forementioned state/identity
@@ -296,7 +296,7 @@ Normalization
 
 After applying the principle of explicit identity to your program, you
 might realise this insight: *the data-model of the application starts
-too look like a data-base!*
+to look like a data-base!*
 
 And you are correct: the model of our application is an in-memory
 data-base, and the Lager store, combined with reducers and actions,


### PR DESCRIPTION
Also it's usually called "database" not "data-base". Should I change that too?

I've seen "datastore" and "data store" being used online. Firefox thinks "datastore" is a typo.