### PR TITLE
state: remove superfluous header

### DIFF
--- a/lager/state.hpp
+++ b/lager/state.hpp
@@ -19,8 +19,6 @@
 
 #include <lager/util.hpp>
 
-#include <iostream>
-
 namespace lager {
 
 struct transactional_tag


### PR DESCRIPTION
From cpp ref:

> Including <iostream> behaves as if it defines a static storage duration object of type std::ios_base::Init, whose constructor initializes the standard stream objects if it is the first std::ios_base::Init object to be constructed, and whose destructor flushes those objects (except for cin and wcin) if it is the last std::ios_base::Init object to be destroyed.

It seems this probably slipped in while debugging, but including `iostream` in a public header isn't necessarily such a great idea for the above reason.