### PR TITLE
Work around VS2019 bug for scope of send down

### DIFF
--- a/lager/detail/xform_nodes.hpp
+++ b/lager/detail/xform_nodes.hpp
@@ -86,7 +86,7 @@ class xform_reader_node<XForm, zug::meta::pack<Parents...>, Base>
 {
     using base_t =
         Base<zug::result_of_t<XForm, zug::meta::value_t<Parents>...>>;
-    using down_rf_t = decltype(std::declval<XForm>()(send_down));
+    using down_rf_t = decltype(std::declval<XForm>()(::lager::detail::send_down));
 
     std::tuple<std::shared_ptr<Parents>...> parents_;
 
@@ -109,7 +109,7 @@ public:
             }
         }())
         , parents_(std::move(parents)...)
-        , down_step_(xform(send_down))
+        , down_step_(xform(::lager::detail::send_down))
     {}
 
     void recompute() /* final */

--- a/lager/extra/qt.hpp
+++ b/lager/extra/qt.hpp
@@ -45,7 +45,7 @@ struct qt_helper
     Q_SIGNAL void name##Changed(const type& name);                             \
     ::lager::detail::qt_helper funq__##name##__initHelper__ = [this] {         \
         ::lager::watch(LAGER_QT(name),                                         \
-                       [this](const type& old, const type& curr) {             \
+					   [this](const type& /*old*/, const type& curr) {         \
                            this->name##Changed(curr);                          \
                        });                                                     \
         return ::lager::detail::qt_helper{};                                   \

--- a/lager/extra/qt.hpp
+++ b/lager/extra/qt.hpp
@@ -45,7 +45,7 @@ struct qt_helper
     Q_SIGNAL void name##Changed(const type& name);                             \
     ::lager::detail::qt_helper funq__##name##__initHelper__ = [this] {         \
         ::lager::watch(LAGER_QT(name),                                         \
-					   [this](const type& /*old*/, const type& curr) {         \
+                       [this](const type& /*old*/, const type& curr) {         \
                            this->name##Changed(curr);                          \
                        });                                                     \
         return ::lager::detail::qt_helper{};                                   \


### PR DESCRIPTION
Also includes a fix for a noisy warning seen with VS2019