### PR TITLE
Better error messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ if(lager_BUILD_TESTS)
   target_include_directories(lager-dev SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${lager_SOURCE_DIR}/>/tools/include")
   target_link_libraries(lager-dev INTERFACE lager
-    ${CMAKE_THREAD_INIT}
-    ${Boost_LIBRARIES})
+    ${Boost_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT})
   if (ENABLE_COVERAGE)
     target_compile_options(lager-dev INTERFACE "--coverage")
     target_link_libraries(lager-dev INTERFACE "--coverage")

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -276,11 +276,26 @@ private:
 //! @defgroup effects
 //! @{
 
+template <typename Action, typename Deps>
+struct effect_for
+{
+    static_assert(
+        is_deps<Deps>::value,
+        LAGER_STATIC_ASSERT_MESSAGE_BEGIN
+        "The second template argument of `lager::effect<...>`, must be a "
+        "lager::deps<>. \n\nMaybe you are trying to specify an effect that can "
+        "dispatch multiple action types? In that case, use the syntax: "
+        "lager::effect<lager::actions<...>, ...>" //
+        LAGER_STATIC_ASSERT_MESSAGE_END);
+
+    using type = std::function<void(const context<Action, Deps>&)>;
+};
+
 /*!
  * Effectful procedure that uses the store context.
  */
 template <typename Action, typename Deps = lager::deps<>>
-using effect = std::function<void(const context<Action, Deps>&)>;
+using effect = typename effect_for<Action, Deps>::type;
 
 //! @} group: effects
 

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -56,6 +56,12 @@ struct as_actions<actions<Actions...>>
     using type = actions<Actions...>;
 };
 
+template <>
+struct as_actions<void>
+{
+    using type = actions<>;
+};
+
 template <typename ActionOrActions>
 using as_actions_t = typename as_actions<ActionOrActions>::type;
 
@@ -226,9 +232,12 @@ struct event_loop_impl final : event_loop_iface
  *       store.  It is invalid to use it after the store has been destructed.
  *       Its methods may modify the store's underlying state.
  *
+ * @note Use action type `void` or empty `lager::actions<>` if `context` shall
+ *       have no `dispatch()` method and only provide deps.
+ *
  * @todo Make constructors private.
  */
-template <typename Actions, typename Deps = lager::deps<>>
+template <typename Actions = void, typename Deps = lager::deps<>>
 struct context : Deps
 {
     using deps_t    = Deps;

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -276,26 +276,32 @@ private:
 //! @defgroup effects
 //! @{
 
-template <typename Action, typename Deps>
-struct effect_for
-{
-    static_assert(
-        is_deps<Deps>::value,
-        LAGER_STATIC_ASSERT_MESSAGE_BEGIN
-        "The second template argument of `lager::effect<...>`, must be a "
-        "lager::deps<>. \n\nMaybe you are trying to specify an effect that can "
-        "dispatch multiple action types? In that case, use the syntax: "
-        "lager::effect<lager::actions<...>, ...>" //
-        LAGER_STATIC_ASSERT_MESSAGE_END);
-
-    using type = std::function<void(const context<Action, Deps>&)>;
-};
-
 /*!
  * Effectful procedure that uses the store context.
  */
 template <typename Action, typename Deps = lager::deps<>>
-using effect = typename effect_for<Action, Deps>::type;
+struct effect : std::function<void(const context<Action, Deps>&)>
+{
+    static_assert(
+        is_deps<Deps>::value,
+        LAGER_STATIC_ASSERT_MESSAGE_BEGIN
+        "The second template argument of `lager::effect<...>`, must be a \
+lager::deps<>. \n\nMaybe you are trying to specify an effect that can dispatch \
+multiple action types? In that case, use the syntax: \
+lager::effect<lager::actions<...>, ...> " //
+        LAGER_STATIC_ASSERT_MESSAGE_END);
+
+    using base_t = std::function<void(const context<Action, Deps>&)>;
+
+    using base_t::base_t;
+    using base_t::operator=;
+
+    effect(const effect&) = default;
+    effect(effect&&)      = default;
+    effect& operator=(const effect&) = default;
+    effect& operator=(effect&&) = default;
+
+};
 
 //! @} group: effects
 

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -312,6 +312,27 @@ lager::effect<lager::actions<...>, ...> " //
 
 };
 
+/*!
+ * Convenience type for specifying the result of reducers that return both a
+ * model and an effect.
+ */
+template <typename Model, typename Action = void, typename Deps = lager::deps<>>
+struct result : std::pair<Model, lager::effect<Action, Deps>>
+{
+    using base_t = std::pair<Model, lager::effect<Action, Deps>>;
+
+    using base_t::base_t;
+
+    result(Model m)
+        : base_t{std::move(m), lager::noop}
+    {}
+
+    result(const result&) = default;
+    result(result&&)      = default;
+    result& operator=(const result&) = default;
+    result& operator=(result&&) = default;
+};
+
 //! @} group: effects
 
 /*!

--- a/lager/context.hpp
+++ b/lager/context.hpp
@@ -344,6 +344,14 @@ lager::effect<lager::actions<...>, ...> " //
     effect& operator=(const effect&) = default;
     effect& operator=(effect&&) = default;
 
+    template <typename A2,
+              typename D2,
+              std::enable_if_t<detail::are_compatible_actions_v<A2, Action> &&
+                                   std::is_convertible_v<Deps, D2>,
+                               int> = 0>
+    effect(effect<A2, D2> e)
+        : base_t{std::move(e)}
+    {}
 };
 
 /*!

--- a/lager/deps.hpp
+++ b/lager/deps.hpp
@@ -488,6 +488,17 @@ bool has(const deps<Ts...>& d)
     return d.template has<Key>();
 }
 
+/*!
+ * Metafunction to see if something is a deps type.
+ */
+template <typename T>
+struct is_deps : std::false_type
+{};
+
+template <typename... Ts>
+struct is_deps<deps<Ts...>> : std::true_type
+{};
+
 //! @}
 
 } // namespace lager

--- a/lager/util.hpp
+++ b/lager/util.hpp
@@ -19,6 +19,9 @@
 
 #define LAGER_FWD(name_) std::forward<decltype(name_)>(name_)
 
+#define LAGER_STATIC_ASSERT_MESSAGE_BEGIN "\n=======================\n\n"
+#define LAGER_STATIC_ASSERT_MESSAGE_END "\n\n=======================\n"
+
 namespace lager {
 
 //! @defgroup util

--- a/shell.nix
+++ b/shell.nix
@@ -2,8 +2,8 @@
   nixpkgs ? (import <nixpkgs> {}).fetchFromGitHub {
     owner  = "NixOS";
     repo   = "nixpkgs";
-    rev    = "5ac6ab091a4883385e68571425fb7fef4d74c207";
-    sha256 = "0rksyhnnj5028n2ql3jkf98vpd8cs1qf6rckgvx9jq2zf1xqsbla";
+    rev    = "053ad4e0db7241ae6a02394d62750fdc5d64aa9f";
+    sha256 = "11l9sr8zg8j1n5p43zjkqwpj59gn8c84z1kf16icnsbnv2smzqdc";
   }}:
 
 with import nixpkgs {};
@@ -31,7 +31,6 @@ in
 theStdenv.mkDerivation rec {
   name = "lager-env";
   buildInputs = [
-    gcc7
     cmake
     ccache
     ncurses
@@ -52,9 +51,9 @@ theStdenv.mkDerivation rec {
     qt5.qtquickcontrols
     qt5.qtquickcontrols2
     qt5.qtgraphicaleffects
-    elmPackages.elm-reactor
-    elmPackages.elm-make
-    elmPackages.elm-package
+    old-nixpkgs.elmPackages.elm-reactor
+    old-nixpkgs.elmPackages.elm-make
+    old-nixpkgs.elmPackages.elm-package
     (python3.withPackages (pkgs: with pkgs; [
       click
       requests

--- a/test/core.cpp
+++ b/test/core.cpp
@@ -42,12 +42,12 @@ TEST_CASE("effect as a result")
     auto view   = [&](auto model) { viewed = model; };
     auto called = 0;
     auto effect = [&](lager::context<int> ctx) { ++called; };
-    auto store =
-        lager::make_store<int>(0,
-                               [=](int model, int action) {
-                                   return std::pair{model + action, effect};
-                               },
-                               lager::with_manual_event_loop{});
+    auto store  = lager::make_store<int>(
+        0,
+        [=](int model, int action) {
+            return std::pair{model + action, effect};
+        },
+        lager::with_manual_event_loop{});
     watch(store, [&](auto&&, auto&& v) { view(v); });
 
     store.dispatch(2);
@@ -64,11 +64,12 @@ TEST_CASE("effects see updated world")
         CHECK(store->get() == 2);
         ++called;
     };
-    store = lager::make_store<int>(0,
-                                   [=](int model, int action) {
-                                       return std::pair{model + action, effect};
-                                   },
-                                   lager::with_manual_event_loop{});
+    store = lager::make_store<int>(
+        0,
+        [=](int model, int action) {
+            return std::pair{model + action, effect};
+        },
+        lager::with_manual_event_loop{});
 
     store->dispatch(2);
     CHECK(called == 1);

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -1,0 +1,28 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#include <catch.hpp>
+
+#include <lager/deps.hpp>
+#include <lager/store.hpp>
+
+#include "../example/counter/counter.hpp"
+
+//
+// Uncomment some of this to see what errors messages one gets
+//
+TEST_CASE("effect with bad multiple actions")
+{
+    // (void) lager::effect<counter::increment_action,
+    // counter::decrement_action>{
+    //     [](auto&& ctx) { ctx.dispatch(counter::increment_action{}); }};
+}

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -22,7 +22,7 @@
 //
 TEST_CASE("effect with bad multiple actions")
 {
-    // (void) lager::effect<counter::increment_action,
-    // counter::decrement_action>{
-    //     [](auto&& ctx) { ctx.dispatch(counter::increment_action{}); }};
+    //(void) lager::effect<counter::increment_action,
+    //counter::decrement_action>{
+    //    [](auto&& ctx) { ctx.dispatch(counter::increment_action{}); }};
 }

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -23,6 +23,12 @@
 TEST_CASE("effect with bad multiple actions")
 {
     //(void) lager::effect<counter::increment_action,
-    //counter::decrement_action>{
+    // counter::decrement_action>{
     //    [](auto&& ctx) { ctx.dispatch(counter::increment_action{}); }};
+}
+
+TEST_CASE("allow context of void")
+{
+    auto ctx = lager::context<>{};
+    // ctx.dispatch();
 }

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -32,3 +32,22 @@ TEST_CASE("allow context of void")
     auto ctx = lager::context<>{};
     // ctx.dispatch();
 }
+
+struct foo
+{};
+
+TEST_CASE("result conversion")
+{
+    // bad model:
+    // lager::result<int>{lager::result<std::string>{""};}
+
+    // bad actions:
+    // lager::result<int>{lager::result<int, int>{0}};
+
+    // bad deps:
+    // lager::result<int>{lager::result<int, void, lager::deps<foo>>{0}};
+
+    // from effect
+    // lager::result<int>{0, lager::effect<int>{}};
+    // lager::result<int>{0, lager::effect<void, lager::deps<int>>{0}};
+}


### PR DESCRIPTION
This branch improves error messages by making `context` and `effect` SFINAE friendly and adding a new `result` type with some static asserts to detect bad signatures in reducers.