### PR TITLE
Make cursors watchers independent of the underlying node

### DIFF
--- a/lager/cursor.hpp
+++ b/lager/cursor.hpp
@@ -33,30 +33,16 @@ struct cursor_mixin
 
 protected:
     ~cursor_mixin() = default;
-
-private:
-    friend class detail::access;
-
-    auto node() const
-    {
-        return detail::access::node(*static_cast<const DerivT*>(this));
-    }
 };
 
 template <typename NodeT>
 class cursor_base
     : public cursor_mixin<cursor_base<NodeT>>
-    , private detail::watchable<zug::meta::value_t<NodeT>>
+    , public watchable_base<NodeT>
 {
-    template <typename T>
-    friend class cursor_base;
     friend class detail::access;
 
-    using base_t = detail::watchable<zug::meta::value_t<NodeT>>;
-
-    using node_ptr_t = std::shared_ptr<NodeT>;
-    node_ptr_t node_;
-    const node_ptr_t& node() const { return node_; }
+    using base_t = watchable_base<NodeT>;
 
 public:
     using value_type = zug::meta::value_t<NodeT>;
@@ -65,13 +51,12 @@ public:
 
     template <typename T>
     cursor_base(cursor_base<T> x)
-        : base_t(std::move(x))
-        , node_(std::move(x.node_))
+        : base_t{std::move(x)}
     {}
 
     template <typename NodeT2>
-    cursor_base(std::shared_ptr<NodeT2> sig)
-        : node_(std::move(sig))
+    cursor_base(std::shared_ptr<NodeT2> n)
+        : base_t{std::move(n)}
     {}
 };
 

--- a/lager/watch.hpp
+++ b/lager/watch.hpp
@@ -14,28 +14,82 @@
 
 #include <boost/signals2/signal.hpp>
 
+#include <zug/meta/value_type.hpp>
+
+#include <memory>
+
 namespace lager {
 
-namespace detail {
-
-template <typename ValueT>
-class watchable
+template <typename NodeT>
+class watchable_base
 {
-    using WatchersT =
-        boost::signals2::signal<void(const ValueT&, const ValueT&)>;
-    WatchersT watchers_;
+    using node_ptr_t = std::shared_ptr<NodeT>;
+    using value_t    = zug::meta::value_t<NodeT>;
+    using signal_t =
+        boost::signals2::signal<void(const value_t&, const value_t&)>;
+    using connection_t = boost::signals2::scoped_connection;
+
+    node_ptr_t node_;
+    signal_t signal_;
+    connection_t conn_;
+
+    const node_ptr_t& node() const { return node_; }
+
+    friend class detail::access;
+    template <typename T>
+    friend class watchable_base;
+
+protected:
+    watchable_base() = default;
+    watchable_base(node_ptr_t p)
+        : node_{std::move(p)}
+    {}
+
+    template <typename T>
+    watchable_base(watchable_base<T> x)
+        : node_(std::move(x.node_))
+    {}
+
+    template <typename NodeT2>
+    watchable_base(std::shared_ptr<NodeT2> n)
+        : node_{std::move(n)}
+    {}
 
 public:
-    watchable() = default;
-    watchable(const watchable& other) noexcept {}
-    watchable(watchable&& other) noexcept {}
-    watchable& operator=(const watchable& other) noexcept { return *this; }
-    watchable& operator=(watchable&& other) noexcept { return *this; }
+    watchable_base(const watchable_base& other) noexcept
+        : node_(other.node_)
+    {}
 
-    WatchersT& watchers() { return watchers_; }
+    watchable_base(watchable_base&& other) noexcept
+        : node_{std::move(other.node_)}
+    {}
+
+    watchable_base& operator=(const watchable_base& other) noexcept
+    {
+        node_ = other.node_;
+        if (!signal_.empty() && node_) {
+            conn_ = node_->observers().connect(signal_);
+        }
+        return *this;
+    }
+
+    watchable_base& operator=(watchable_base&& other) noexcept
+    {
+        node_ = std::move(other.node_);
+        if (!signal_.empty() && node_) {
+            conn_ = node_->observers().connect(signal_);
+        }
+        return *this;
+    }
+
+    template <typename CallbackT>
+    auto watch(CallbackT&& callback)
+    {
+        if (signal_.empty() && node_)
+            conn_ = node_->observers().connect(signal_);
+        return signal_.connect(std::forward<CallbackT>(callback));
+    }
 };
-
-} // namespace detail
 
 /*!
  * Watch changes through a reader using callback @callback.
@@ -43,13 +97,7 @@ public:
 template <typename ReaderT, typename CallbackT>
 auto watch(ReaderT&& value, CallbackT&& callback)
 {
-    auto& watchers = detail::access::watchers(std::forward<ReaderT>(value));
-    if (watchers.empty()) {
-        detail::access::node(std::forward<ReaderT>(value))
-            ->observers()
-            .connect(watchers);
-    }
-    return watchers.connect(std::forward<CallbackT>(callback));
+    return value.watch(std::forward<CallbackT>(callback));
 }
 
 } // namespace lager

--- a/lager/writer.hpp
+++ b/lager/writer.hpp
@@ -28,13 +28,13 @@ struct writer_mixin
     template <typename T>
     void set(T&& value)
     {
-        return node()->send_up(std::forward<T>(value));
+        return node_()->send_up(std::forward<T>(value));
     }
 
     template <typename Fn>
     void update(Fn&& fn)
     {
-        return node()->send_up(std::forward<Fn>(fn)(node()->current()));
+        return node_()->send_up(std::forward<Fn>(fn)(node_()->current()));
     }
 
     template <typename T>
@@ -48,16 +48,14 @@ struct writer_mixin
     template <typename Xform, typename Xform2>
     auto xf(Xform&& xf, Xform2&& xf2) const
     {
-        return xform(xf, xf2)(*this);
+        return xform(xf, xf2)(static_cast<const DerivT&>(*this));
     }
 
 protected:
     ~writer_mixin() = default;
 
 private:
-    friend class detail::access;
-
-    auto node() const
+    auto node_() const
     {
         return detail::access::node(*static_cast<const DerivT*>(this));
     }

--- a/lager/xform.hpp
+++ b/lager/xform.hpp
@@ -104,7 +104,7 @@ auto zoom(LensT&& l, const reader_mixin<ReaderTs>&... ins)
 {
     return xform(zug::map([l](auto&& x) {
         return lager::view(l, std::forward<decltype(x)>(x));
-    }))(ins...);
+    }))(static_cast<const ReaderTs&>(ins)...);
 }
 
 template <typename LensT, typename... CursorTs>
@@ -119,7 +119,7 @@ auto zoom(LensT&& l, const writer_mixin<CursorTs>&... ins)
             return lager::set(l,
                               std::forward<decltype(x)>(x),
                               zug::tuplify(std::forward<decltype(vs)>(vs)...));
-        }))(ins...);
+        }))(static_cast<const CursorTs&>(ins)...);
 }
 
 template <typename LensT, typename... CursorTs>

--- a/test/watchers.cpp
+++ b/test/watchers.cpp
@@ -1,0 +1,42 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#include <catch.hpp>
+
+#include <lager/state.hpp>
+
+TEST_CASE("watch before assign")
+{
+    auto c      = lager::cursor<int>{};
+    auto called = 0;
+    auto value  = -1;
+    watch(c, [&](auto, auto x) {
+        ++called;
+        value = x;
+    });
+
+    auto s = lager::state<int, lager::automatic_tag>(42);
+    c      = s;
+    CHECK(called == 0);
+    CHECK(value == -1);
+
+    s.set(5);
+    CHECK(called == 1);
+    CHECK(value == 5);
+    CHECK(c.get() == 5);
+
+    c = lager::state<int, lager::automatic_tag>(2);
+    c.set(4);
+    CHECK(called == 2);
+    CHECK(value == 4);
+    CHECK(c.get() == 4);
+}


### PR DESCRIPTION
When you watch a cursor, connection will be logically maintained with
whatever underlying cursor it is associated to.

Note that when you change the cursor, the watcher is not emitted.  The
reason is that this may cause problems if watchers are expected to be
called in a specific time of the event loop (e.g. whenever committing
states or other roots is actually done).  Normally whoever assigns the
cursor assignment has all the information available anyways to perform
the notification themselves, if necessary at all.

Fixes #34 and #33 