### PR TITLE
Make watching infrastructure more light weight

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,7 +7,6 @@ cc_library(
     ]),
     deps = [
         "@boost//:hana",
-        "@boost//:signals2",
         "@zug//:zug",
     ],
     includes = [".", "lager/"],

--- a/example/autopong/sdl2/main.cpp
+++ b/example/autopong/sdl2/main.cpp
@@ -18,14 +18,13 @@
 #include <lager/debug/debugger.hpp>
 #include <lager/debug/http_server.hpp>
 #include <lager/event_loop/sdl.hpp>
-#include <lager/store.hpp>
 #include <lager/resources_path.hpp>
+#include <lager/store.hpp>
 
 #include <cmath>
 #include <iostream>
 #include <string>
 #include <variant>
-
 
 constexpr auto font_size = 32;
 
@@ -145,7 +144,8 @@ int main(int argc, const char** argv)
     SDL_SetRelativeMouseMode(SDL_TRUE);
 
 #ifdef DEBUGGER
-    auto debugger = lager::http_debug_server{argc, argv, 8080, lager::resources_path()};
+    auto debugger =
+        lager::http_debug_server{argc, argv, 8080, lager::resources_path()};
 #endif
     auto view = sdl_view{};
     auto loop = lager::sdl_event_loop{};
@@ -159,7 +159,7 @@ int main(int argc, const char** argv)
                                             lager::identity
 #endif
         );
-    watch(store, [&](auto&&, auto&& val) { draw(view, LAGER_FWD(val)); });
+    watch(store, [&](auto&& val) { draw(view, LAGER_FWD(val)); });
     loop.run(
         [&](const SDL_Event& ev) {
             if (auto act = intent(ev))

--- a/example/counter/ncurses/main.cpp
+++ b/example/counter/ncurses/main.cpp
@@ -17,8 +17,8 @@
 #include <lager/debug/http_server.hpp>
 #include <lager/debug/tree_debugger.hpp>
 #include <lager/event_loop/boost_asio.hpp>
-#include <lager/store.hpp>
 #include <lager/resources_path.hpp>
+#include <lager/store.hpp>
 
 #include <zug/compose.hpp>
 
@@ -62,10 +62,12 @@ int main(int argc, const char** argv)
     ::init_pair(2, COLOR_WHITE, COLOR_RED);
     ::init_pair(3, COLOR_WHITE, COLOR_BLUE);
 #if defined(DEBUGGER) || defined(TREE_DEBUGGER)
-    auto debugger = lager::http_debug_server{argc, argv, 8080, lager::resources_path()};
+    auto debugger =
+        lager::http_debug_server{argc, argv, 8080, lager::resources_path()};
 #endif
 #ifdef META_DEBUGGER
-    auto meta_debugger = lager::http_debug_server{argc, argv, 8081, lager::resources_path()};
+    auto meta_debugger =
+        lager::http_debug_server{argc, argv, 8081, lager::resources_path()};
 #endif
     auto store = lager::make_store<counter::action>(
         counter::model{},
@@ -83,7 +85,7 @@ int main(int argc, const char** argv)
 #endif
             lager::identity));
 
-    watch(store, [](auto&&, auto&& val) { draw(unwrap(val)); });
+    watch(store, [](auto&& val) { draw(unwrap(val)); });
     draw(unwrap(store.get()));
 
     term.start([&](auto ev) {

--- a/example/counter/sdl2/main.cpp
+++ b/example/counter/sdl2/main.cpp
@@ -15,8 +15,8 @@
 
 #include "../counter.hpp"
 #include <lager/event_loop/sdl.hpp>
-#include <lager/store.hpp>
 #include <lager/resources_path.hpp>
+#include <lager/store.hpp>
 
 #include <iostream>
 #include <string>
@@ -96,7 +96,7 @@ int main()
     auto store = lager::make_store<counter::action>(
         counter::model{}, counter::update, lager::with_sdl_event_loop{loop});
 
-    watch(store, [&](auto&&, auto&& val) { draw(view, val); });
+    watch(store, [&](auto&& val) { draw(view, val); });
     draw(view, store.get());
 
     loop.run([&](const SDL_Event& ev) {

--- a/example/counter/std/main.cpp
+++ b/example/counter/std/main.cpp
@@ -15,9 +15,8 @@
 #include <lager/event_loop/manual.hpp>
 #include <lager/store.hpp>
 
-void draw(counter::model prev, counter::model curr)
+void draw(counter::model curr)
 {
-    std::cout << "last value: " << prev.value << '\n';
     std::cout << "current value: " << curr.value << '\n';
 }
 

--- a/example/snake/qml/main.cpp
+++ b/example/snake/qml/main.cpp
@@ -36,8 +36,7 @@ int main(int argc, char** argv)
         std::move(initial_state), update, lager::with_qt_event_loop{app});
 
     Game game{store};
-    watch(store,
-          [&](auto&& /*old*/, auto&& state) { game.setModel(state.game); });
+    watch(store, [&](auto&& state) { game.setModel(state.game); });
     game.setModel(store.get().game);
 
     auto* qmlContext = engine.rootContext();

--- a/lager/constant.hpp
+++ b/lager/constant.hpp
@@ -20,12 +20,14 @@ namespace lager {
 namespace detail {
 
 template <typename T>
-class constant_node : public reader_node<T>
+class constant_node : public root_node<T, reader_node>
 {
-    using base_t = reader_node<T>;
+    using base_t = root_node<T, reader_node>;
 
 public:
     using base_t::base_t;
+
+    virtual void recompute() final {}
 };
 
 template <typename T>

--- a/lager/detail/lens_nodes.hpp
+++ b/lager/detail/lens_nodes.hpp
@@ -84,13 +84,13 @@ public:
 
     void send_up(const value_type& value) final
     {
-        this->recompute_deep();
+        this->refresh();
         this->push_up(set(this->lens_, current_from(this->parents()), value));
     }
 
     void send_up(value_type&& value) final
     {
-        this->recompute_deep();
+        this->refresh();
         this->push_up(
             set(this->lens_, current_from(this->parents()), std::move(value)));
     }

--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -38,9 +38,8 @@
 
 #pragma once
 
+#include <lager/detail/signal.hpp>
 #include <lager/util.hpp>
-
-#include <boost/signals2/signal.hpp>
 
 #include <zug/meta/pack.hpp>
 #include <zug/tuplify.hpp>
@@ -120,7 +119,8 @@ template <typename T>
 class reader_node : public reader_node_base
 {
 public:
-    using value_type = T;
+    using value_type  = T;
+    using signal_type = signal<const value_type&, const value_type&>;
 
     reader_node(T value)
         : current_(std::move(value))
@@ -193,17 +193,7 @@ public:
         }
     }
 
-    template <typename Fn>
-    auto observe(Fn&& f) -> boost::signals2::connection
-    {
-        return observers_.connect(std::forward<Fn>(f));
-    }
-
-    auto observers()
-        -> boost::signals2::signal<void(const value_type&, const value_type&)>&
-    {
-        return observers_;
-    }
+    auto observers() -> signal_type& { return observers_; }
 
 private:
     void collect()
@@ -221,8 +211,7 @@ private:
     value_type last_;
     value_type last_notified_;
     std::vector<std::weak_ptr<reader_node_base>> children_;
-    boost::signals2::signal<void(const value_type&, const value_type&)>
-        observers_;
+    signal_type observers_;
 };
 
 /*!

--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -120,12 +120,11 @@ class reader_node : public reader_node_base
 {
 public:
     using value_type  = T;
-    using signal_type = signal<const value_type&, const value_type&>;
+    using signal_type = signal<const value_type&>;
 
     reader_node(T value)
         : current_(std::move(value))
         , last_(current_)
-        , last_notified_(current_)
     {}
 
     virtual void recompute() {}
@@ -175,8 +174,7 @@ public:
         using namespace std;
         if (!needs_send_down_ && needs_notify_) {
             needs_notify_ = false;
-            observers_(last_notified_, last_);
-            last_notified_ = last_;
+            observers_(last_);
 
             auto garbage = false;
             for (std::size_t i = 0, size = children_.size(); i < size; ++i) {
@@ -209,7 +207,6 @@ private:
     bool needs_notify_    = false;
     value_type current_;
     value_type last_;
-    value_type last_notified_;
     std::vector<std::weak_ptr<reader_node_base>> children_;
     signal_type observers_;
 };

--- a/lager/detail/signal.hpp
+++ b/lager/detail/signal.hpp
@@ -1,0 +1,100 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#pragma once
+
+#include <boost/intrusive/list.hpp>
+
+namespace lager {
+namespace detail {
+
+template <typename... Args>
+struct forwarder;
+
+template <typename... Args>
+class signal
+{
+    using slot_list_base = boost::intrusive::list_base_hook<
+        boost::intrusive::link_mode<boost::intrusive::auto_unlink>>;
+
+public:
+    using forwarder_type = forwarder<Args...>;
+
+    struct slot_base : slot_list_base
+    {
+        virtual ~slot_base()             = default;
+        virtual void operator()(Args...) = 0;
+    };
+
+    template <typename Fn>
+    class slot : public slot_base
+    {
+        Fn fn_;
+
+    public:
+        slot(Fn fn)
+            : fn_{std::move(fn)}
+        {}
+        void operator()(Args... args) final { fn_(args...); }
+    };
+
+    struct connection
+    {
+        std::unique_ptr<slot_base> slot_;
+
+    public:
+        connection(std::unique_ptr<slot_base> s)
+            : slot_{std::move(s)}
+        {}
+    };
+
+    template <typename Fn>
+    connection connect(Fn&& fn)
+    {
+        using slot_t = slot<std::decay_t<Fn>>;
+        auto s       = std::make_unique<slot_t>(std::forward<Fn>(fn));
+        slots_.push_back(*s);
+        return {std::move(s)};
+    }
+
+    void add(slot_base& slot) { slots_.push_back(slot); }
+
+    template <typename... Args2>
+    void operator()(Args2&&... args)
+    {
+        for (auto&& s : slots_)
+            s(std::forward<Args2>(args)...);
+    }
+
+    bool empty() const { return slots_.empty(); }
+
+private:
+    using slot_list =
+        boost::intrusive::list<slot_base,
+                               boost::intrusive::constant_time_size<false>>;
+
+    slot_list slots_;
+};
+
+template <typename... Args>
+struct forwarder
+    : signal<Args...>::slot_base
+    , signal<Args...>
+{
+    void operator()(Args... args) override
+    {
+        signal<Args...>::operator()(args...);
+    }
+};
+
+} // namespace detail
+} // namespace lager

--- a/lager/extra/qt.hpp
+++ b/lager/extra/qt.hpp
@@ -44,10 +44,9 @@ struct qt_helper
 #define LAGER_QT_SIGNAL_DETAIL(type, name)                                     \
     Q_SIGNAL void name##Changed(const type& name);                             \
     ::lager::detail::qt_helper funq__##name##__initHelper__ = [this] {         \
-        ::lager::watch(LAGER_QT(name),                                         \
-                       [this](const type& /*old*/, const type& curr) {         \
-                           this->name##Changed(curr);                          \
-                       });                                                     \
+        ::lager::watch(LAGER_QT(name), [this](const type& curr) {              \
+            this->name##Changed(curr);                                         \
+        });                                                                    \
         return ::lager::detail::qt_helper{};                                   \
     }() /**/
 

--- a/lager/sensor.hpp
+++ b/lager/sensor.hpp
@@ -20,9 +20,9 @@ namespace lager {
 namespace detail {
 
 template <typename T>
-class sensor_node_base : public reader_node<T>
+class sensor_node_base : public root_node<T, reader_node>
 {
-    using base_t = reader_node<T>;
+    using base_t = root_node<T, reader_node>;
 
 public:
     using base_t::base_t;

--- a/lager/state.hpp
+++ b/lager/state.hpp
@@ -25,12 +25,16 @@ namespace lager {
 namespace detail {
 
 template <typename T, typename TagT = transactional_tag>
-class state_node : public cursor_node<T>
+class state_node : public root_node<T, cursor_node>
 {
+    using base_t = root_node<T, cursor_node>;
+
 public:
     using value_type = T;
 
-    using cursor_node<T>::cursor_node;
+    using base_t::base_t;
+
+    virtual void recompute() final {}
 
     void send_up(const value_type& value) final
     {

--- a/lager/store.hpp
+++ b/lager/store.hpp
@@ -27,14 +27,15 @@ namespace lager {
 namespace detail {
 
 template <typename Action, typename Model>
-struct store_node_base : public reader_node<Model>
+struct store_node_base : public root_node<Model, reader_node>
 {
     using action_t   = Action;
     using model_t    = Model;
     using value_type = Model;
+    using base_t     = root_node<Model, reader_node>;
+    using base_t::base_t;
 
-    using reader_node<Model>::reader_node;
-
+    virtual void recompute() final {}
     virtual void dispatch(action_t action) = 0;
 };
 

--- a/lager/with.hpp
+++ b/lager/with.hpp
@@ -55,7 +55,7 @@ auto update(UpdateT&& updater)
 {
     return [=](auto&& step) {
         return [=](auto s, auto&&... is) mutable {
-            s->recompute_deep();
+            s->refresh();
             return step(s, updater(current_from(s->parents()), ZUG_FWD(is)...));
         };
     };

--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,8 @@ let
   theStdenv     = if compilerPkg.isClang
                   then clangStdenv
                   else stdenv;
+  qt            = qt5;
+  qtver         = qt.qtbase.version;
 
 in
 theStdenv.mkDerivation rec {
@@ -47,11 +49,11 @@ theStdenv.mkDerivation rec {
     SDL2
     SDL2_ttf
     emscripten
-    qt5.qtbase
-    qt5.qtdeclarative
-    qt5.qtquickcontrols
-    qt5.qtquickcontrols2
-    qt5.qtgraphicaleffects
+    qt.qtbase
+    qt.qtdeclarative
+    qt.qtquickcontrols
+    qt.qtquickcontrols2
+    qt.qtgraphicaleffects
     (python3.withPackages (pkgs: with pkgs; [
       click
       requests
@@ -73,12 +75,11 @@ theStdenv.mkDerivation rec {
     addToSearchPath PATH "$LAGER_ROOT/build"
     addToSearchPath PATH "$LAGER_ROOT/build/example"
     addToSearchPath PATH "$LAGER_ROOT/build/test"
-    addToSearchPath QML2_IMPORT_PATH ${qt5.qtdeclarative.bin}/lib/qt-5.11/qml
-    addToSearchPath QML2_IMPORT_PATH ${qt5.qtquickcontrols}/lib/qt-5.11/qml
-    addToSearchPath QML2_IMPORT_PATH ${qt5.qtquickcontrols2.bin}/lib/qt-5.11/qml
-    addToSearchPath QML2_IMPORT_PATH ${qt5.qtgraphicaleffects}/lib/qt-5.11/qml
-    addToSearchPath QT_PLUGIN_PATH ${qt5.qtsvg.bin}/lib/qt-5.11/plugins
-    export QT_QPA_PLATFORM_PLUGIN_PATH=${qt5.qtbase}/lib/qt-5.11/plugins
+    addToSearchPath QML2_IMPORT_PATH ${qt512.qtquickcontrols}/lib/qt-${qtver}/qml
+    addToSearchPath QML2_IMPORT_PATH ${qt512.qtquickcontrols2.bin}/lib/qt-${qtver}/qml
+    addToSearchPath QML2_IMPORT_PATH ${qt512.qtgraphicaleffects}/lib/qt-${qtver}/qml
+    addToSearchPath QT_PLUGIN_PATH ${qt512.qtsvg.bin}/lib/qt-${qtver}/plugins
+    export QT_QPA_PLATFORM_PLUGIN_PATH=${qt512.qtbase}/lib/qt-${qtver}/plugins
     export IMGUI_SOURCE_DIR=${deps.imgui}
   '';
 }

--- a/test/core.cpp
+++ b/test/core.cpp
@@ -24,7 +24,7 @@ TEST_CASE("automatic")
     auto view   = [&](auto model) { viewed = model; };
     auto store  = lager::make_store<counter::action>(
         counter::model{}, counter::update, lager::with_manual_event_loop{});
-    watch(store, [&](auto&&, auto&& v) { view(v); });
+    watch(store, [&](auto&& v) { view(v); });
 
     CHECK(!viewed);
     CHECK(viewed->value == 0);
@@ -42,7 +42,7 @@ TEST_CASE("basic")
     auto view   = [&](auto model) { viewed = model; };
     auto store  = lager::make_store<counter::action, lager::transactional_tag>(
         counter::model{}, counter::update, lager::with_manual_event_loop{});
-    watch(store, [&](auto&&, auto&& v) { view(v); });
+    watch(store, [&](auto&& v) { view(v); });
 
     CHECK(!viewed);
     CHECK(viewed->value == 0);
@@ -70,7 +70,7 @@ TEST_CASE("effect as a result")
             return std::pair{model + action, effect};
         },
         lager::with_manual_event_loop{});
-    watch(store, [&](auto&&, auto&& v) { view(v); });
+    watch(store, [&](auto&& v) { view(v); });
 
     store.dispatch(2);
     CHECK(viewed);
@@ -105,7 +105,7 @@ TEST_CASE("store type erasure")
     lager::store<counter::action, counter::model> store =
         lager::make_store<counter::action>(
             counter::model{}, counter::update, lager::with_manual_event_loop{});
-    watch(store, [&](auto&&, auto&& v) { view(v); });
+    watch(store, [&](auto&& v) { view(v); });
     CHECK(!viewed);
 
     store.dispatch(counter::increment_action{});

--- a/test/detail/nodes.cpp
+++ b/test/detail/nodes.cpp
@@ -73,10 +73,7 @@ TEST_CASE("node, sending down")
 TEST_CASE("node, notifies new and previous value after send down")
 {
     auto x = make_state_node(5);
-    auto s = testing::spy([](int last, int next) {
-        CHECK(5 == last);
-        CHECK(42 == next);
-    });
+    auto s = testing::spy([](int next) { CHECK(42 == next); });
     auto c = x->observers().connect(s);
 
     x->send_up(42);
@@ -145,8 +142,7 @@ TEST_CASE("node, observing is consistent")
     auto z = make_xform_reader_node(identity, std::make_tuple(x));
     auto w = make_xform_reader_node(identity, std::make_tuple(y));
 
-    auto s = testing::spy([&](int last_value, int new_value) {
-        CHECK(5 == last_value);
+    auto s = testing::spy([&](int new_value) {
         CHECK(42 == new_value);
         CHECK(42 == x->last());
         CHECK(42 == y->last());
@@ -253,9 +249,8 @@ TEST_CASE("node, one node two parents")
     auto y    = make_state_node(12);
     auto z    = make_xform_reader_node(map([](int a, int b) { return a + b; }),
                                     std::make_tuple(x, y));
-    auto s =
-        testing::spy([&](int, int r) { CHECK(r == x->last() + y->last()); });
-    auto c = z->observers().connect(s);
+    auto s    = testing::spy([&](int r) { CHECK(r == x->last() + y->last()); });
+    auto c    = z->observers().connect(s);
     CHECK(12 == z->last());
 
     // Commit first root individually

--- a/test/sensor.cpp
+++ b/test/sensor.cpp
@@ -49,18 +49,14 @@ TEST_CASE("sensor, looks up only on commit")
 
 TEST_CASE("sensor, watching")
 {
-    auto expected_old  = 0;
-    auto expected_curr = 1;
-    auto x             = make_sensor(counter{});
-    auto s             = testing::spy([&](std::size_t old, std::size_t curr) {
-        CHECK(expected_old == old);
-        CHECK(expected_curr == curr);
-    });
+    auto expected = 1;
+    auto x        = make_sensor(counter{});
+    auto s = testing::spy([&](std::size_t curr) { CHECK(expected == curr); });
     watch(x, s);
     CHECK(0 == s.count());
     commit(x);
     CHECK(1 == s.count());
-    ++expected_curr, ++expected_old;
+    ++expected;
     commit(x);
     CHECK(2 == s.count());
 }

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -114,14 +114,12 @@ TEST_CASE("state, watches always view consistent state")
 {
     auto x  = make_state(42);
     auto y  = make_state(35);
-    auto sx = testing::spy([&](int old, int curr) {
-        CHECK(42 == old);
+    auto sx = testing::spy([&](int curr) {
         CHECK(84 == curr);
         CHECK(x.get() == 84);
         CHECK(y.get() == 70);
     });
-    auto sy = testing::spy([&](int old, int curr) {
-        CHECK(35 == old);
+    auto sy = testing::spy([&](int curr) {
         CHECK(70 == curr);
         CHECK(x.get() == 84);
         CHECK(y.get() == 70);
@@ -144,14 +142,12 @@ TEST_CASE("state, watches automatic can show inconsistent state")
 {
     auto x  = make_state(42, automatic_tag{});
     auto y  = make_state(35, automatic_tag{});
-    auto sx = testing::spy([&](int old, int curr) {
-        CHECK(42 == old);
+    auto sx = testing::spy([&](int curr) {
         CHECK(84 == curr);
         CHECK(x.get() == 84);
         CHECK(y.get() == 35);
     });
-    auto sy = testing::spy([&](int old, int curr) {
-        CHECK(35 == old);
+    auto sy = testing::spy([&](int curr) {
         CHECK(70 == curr);
         CHECK(x.get() == 84);
         CHECK(y.get() == 70);

--- a/test/watchers.cpp
+++ b/test/watchers.cpp
@@ -19,7 +19,7 @@ TEST_CASE("watch before assign")
     auto c      = lager::cursor<int>{};
     auto called = 0;
     auto value  = -1;
-    watch(c, [&](auto, auto x) {
+    watch(c, [&](auto x) {
         ++called;
         value = x;
     });


### PR DESCRIPTION
First, we use our own signal implementation instead of boost signals2.

**Warning:** API breaking change! The previous value is not passed to watchers anymore. This is easy to workaround if needed though:
```cpp
data.watch([last=data.get()](auto&& curr) {
    // ...
    last = curr;
});
```