### PR TITLE
Introduce tuple lenses

### DIFF
--- a/lager/lenses/at.hpp
+++ b/lager/lenses/at.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <optional>
-#include <stdexcept>
-#include <utility>
+#include <lager/util.hpp>
 
 #include <zug/compose.hpp>
 #include <zug/meta/detected.hpp>
 
-#include <lager/util.hpp>
+#include <optional>
+#include <stdexcept>
+#include <utility>
 
 namespace lager {
 namespace lenses {

--- a/lager/lenses/at_or.hpp
+++ b/lager/lenses/at_or.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <optional>
-#include <stdexcept>
-#include <utility>
+#include <lager/util.hpp>
 
 #include <zug/compose.hpp>
 #include <zug/meta/detected.hpp>
 
-#include <lager/util.hpp>
+#include <optional>
+#include <stdexcept>
+#include <utility>
 
 namespace lager {
 namespace lenses {

--- a/lager/lenses/attr.hpp
+++ b/lager/lenses/attr.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <utility>
-
 #include <lager/util.hpp>
 #include <zug/compose.hpp>
+
+#include <utility>
 
 namespace lager {
 namespace lenses {

--- a/lager/lenses/optional.hpp
+++ b/lager/lenses/optional.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
-#include <optional>
-#include <type_traits>
-#include <utility>
-
 #include <lager/lenses.hpp>
 #include <lager/util.hpp>
+
 #include <zug/compose.hpp>
 #include <zug/meta/detected.hpp>
 #include <zug/meta/util.hpp>
+
+#include <optional>
+#include <type_traits>
+#include <utility>
 
 namespace lager {
 namespace lenses {

--- a/lager/lenses/tuple.hpp
+++ b/lager/lenses/tuple.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <tuple>
-#include <type_traits>
-
 #include <lager/lenses.hpp>
 #include <lager/lenses/attr.hpp>
+
+#include <tuple>
+#include <type_traits>
 
 namespace lager {
 namespace lenses {

--- a/lager/lenses/tuple.hpp
+++ b/lager/lenses/tuple.hpp
@@ -148,7 +148,7 @@ auto zip(Lenses&&... lenses)
  * overwrite sequential writes to the part. just don't do it.
  */
 template <typename... Lenses>
-auto explode(Lenses&&... lenses)
+auto fan(Lenses&&... lenses)
 {
     return zug::comp([lens_tuple =
                           std::make_tuple(LAGER_FWD(lenses)...)](auto&& f) {
@@ -168,13 +168,13 @@ auto explode(Lenses&&... lenses)
 /**
  * (Part Whole::*)... -> Lens<Whole, (Part...)>
  *
- * Note: for the same reason as detailed in explode, the members
+ * Note: for the same reason as detailed in fan, the members
  * should be distinct from each other.
  */
 template <typename... Member>
 auto attr(Member... member)
 {
-    return explode(attr(member)...);
+    return fan(attr(member)...);
 }
 
 /**

--- a/lager/lenses/tuple.hpp
+++ b/lager/lenses/tuple.hpp
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+#include <lager/lenses.hpp>
+#include <lager/lenses/attr.hpp>
+
+namespace lager {
+namespace lenses {
+namespace detail {
+
+template <typename T>
+struct templated_type_contructor;
+
+template <template <typename...> typename T, typename... Params>
+struct templated_type_contructor<T<Params...>>
+{
+    template <typename... Ts>
+    static auto construct(Ts&&... ps)
+    {
+        return T<std::remove_reference_t<Ts>...>{std::forward<Ts>(ps)...};
+    }
+};
+
+template <size_t I, typename... Tuples>
+decltype(auto) multiget(Tuples&&... tuples)
+{
+    return std::forward_as_tuple(std::get<I>(std::forward<Tuples>(tuples))...);
+};
+
+template <typename ResType, typename F, typename... Tuples, size_t... Seq>
+decltype(auto) apply_zip_impl(std::index_sequence<Seq...>, F&& f, Tuples&&... t)
+{
+    return templated_type_contructor<ResType>::construct(std::apply(
+        std::forward<F>(f), multiget<Seq>(std::forward<Tuples>(t)...))...);
+}
+
+template <typename ResType, typename F, typename... Tuple>
+decltype(auto) apply_zip(F&& f, Tuple&&... t)
+{
+    constexpr size_t len =
+        std::min({std::tuple_size_v<std::remove_reference_t<Tuple>>...});
+    return apply_zip_impl<ResType>(std::make_index_sequence<len>{},
+                                   std::forward<F>(f),
+                                   std::forward<Tuple>(t)...);
+}
+
+namespace fold_op {
+template <typename Init, typename Elem>
+decltype(auto) operator+(Init&& init, Elem&& elem)
+{
+    auto&& [lens, part] = LAGER_FWD(elem);
+    return ::lager::set(LAGER_FWD(lens), LAGER_FWD(init), LAGER_FWD(part));
+}
+} // namespace fold_op
+
+template <typename Whole, typename LensTuple, typename PartTuple, size_t... Seq>
+decltype(auto) set_fold_impl(Whole&& whole,
+                             LensTuple&& lenses,
+                             PartTuple&& parts,
+                             std::index_sequence<Seq...>)
+{
+    using fold_op::operator+;
+    return (LAGER_FWD(whole) + ... +
+            multiget<Seq>(LAGER_FWD(lenses), LAGER_FWD(parts)));
+}
+
+template <typename Whole, typename LensTuple, typename PartTuple>
+decltype(auto) set_fold(Whole&& whole, LensTuple&& lenses, PartTuple&& parts)
+{
+    return set_fold_impl(
+        LAGER_FWD(whole),
+        LAGER_FWD(lenses),
+        LAGER_FWD(parts),
+        std::make_index_sequence<
+            std::tuple_size_v<std::remove_reference_t<LensTuple>>>());
+}
+
+// note: has to be const & to avoid potential moved from UB
+template <class T, size_t... Seq>
+auto dup_impl(T const& x, std::index_sequence<Seq...>)
+{
+    return std::tuple<decltype(static_cast<void>(Seq), x)...>(
+        (static_cast<void>(Seq), x)...);
+}
+
+template <size_t N, class T>
+auto dup(T&& x)
+{
+    return dup_impl(LAGER_FWD(x), std::make_index_sequence<N>());
+}
+
+inline auto fobj_view = [](auto&&... args) { return view(LAGER_FWD(args)...); };
+inline auto fobj_set  = [](auto&&... args) { return set(LAGER_FWD(args)...); };
+
+// due to some obscure behavior on MSVC, this has to be implemented in a
+// manually defined function object
+template <size_t N>
+struct element_t : zug::detail::pipeable
+{
+    template <typename F>
+    auto operator()(F&& f) const
+    {
+        return [f = std::forward<F>(f)](auto&& whole) {
+            return f(std::get<N>(LAGER_FWD(whole)))([&](auto&& part) {
+                auto res         = LAGER_FWD(whole);
+                std::get<N>(res) = LAGER_FWD(part);
+                return res;
+            });
+        };
+    }
+};
+
+} // namespace detail
+
+//! @defgroup lenses
+//! @{
+
+/**
+ * Lens<W1, P1>, ..., Lens<Wn, Pn> -> Lens<(W1, ..., Wn), (P1, ..., Pn)>
+ *
+ * Note: remember you can use the identity function as the identity lens.
+ */
+template <typename... Lenses>
+auto zip(Lenses&&... lenses)
+{
+    return zug::comp(
+        [lens_tuple = std::make_tuple(LAGER_FWD(lenses)...)](auto&& f) {
+            return [&, f = LAGER_FWD(f)](auto&& whole_tuple) {
+                using Whole = std::decay_t<decltype(whole_tuple)>;
+                return f(detail::apply_zip<Whole>(
+                    detail::fobj_view, lens_tuple, LAGER_FWD(whole_tuple)))(
+                    [&](auto&& part_tuple) {
+                        return detail::apply_zip<Whole>(detail::fobj_set,
+                                                        lens_tuple,
+                                                        LAGER_FWD(whole_tuple),
+                                                        LAGER_FWD(part_tuple));
+                    });
+            };
+        });
+}
+
+/**
+ * Lens<W, P1>, ..., Lens<W, Pn> -> Lens<W, (P1, ..., Pn)>
+ *
+ * Note: parts MUST NOT OVERLAP. if they do the fold will
+ * overwrite sequential writes to the part. just don't do it.
+ */
+template <typename... Lenses>
+auto explode(Lenses&&... lenses)
+{
+    return zug::comp([lens_tuple =
+                          std::make_tuple(LAGER_FWD(lenses)...)](auto&& f) {
+        return [&, f = LAGER_FWD(f)](auto&& whole) {
+            auto whole_tuple = detail::dup<sizeof...(Lenses)>(LAGER_FWD(whole));
+            using Whole      = std::decay_t<decltype(whole_tuple)>;
+            return f(detail::apply_zip<Whole>(
+                detail::fobj_view, lens_tuple, whole_tuple))(
+                [&](auto&& part_tuple) {
+                    return detail::set_fold(
+                        LAGER_FWD(whole), lens_tuple, LAGER_FWD(part_tuple));
+                });
+        };
+    });
+}
+
+/**
+ * (Part Whole::*)... -> Lens<Whole, (Part...)>
+ *
+ * Note: for the same reason as detailed in explode, the members
+ * should be distinct from each other.
+ */
+template <typename... Member>
+auto attr(Member... member)
+{
+    return explode(attr(member)...);
+}
+
+/**
+ * N -> Lens<(P1, ..., Pn), PN>
+ *
+ * Note: works for pairs, tuples, arrays. don't use on variants.
+ */
+template <size_t N>
+auto element = detail::element_t<N>{};
+
+inline auto first  = element<0>;
+inline auto second = element<1>;
+
+//! @}
+
+} // namespace lenses
+} // namespace lager

--- a/lager/lenses/tuple.hpp
+++ b/lager/lenses/tuple.hpp
@@ -183,7 +183,7 @@ auto attr(Member... member)
  * Note: works for pairs, tuples, arrays. don't use on variants.
  */
 template <size_t N>
-auto element = detail::element_t<N>{};
+inline auto element = detail::element_t<N>{};
 
 inline auto first  = element<0>;
 inline auto second = element<1>;

--- a/lager/lenses/unbox.hpp
+++ b/lager/lenses/unbox.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <utility>
-
 #include <lager/util.hpp>
 #include <zug/compose.hpp>
+
+#include <utility>
 
 namespace lager {
 namespace lenses {

--- a/lager/lenses/variant.hpp
+++ b/lager/lenses/variant.hpp
@@ -44,7 +44,7 @@ struct alternative_t : zug::detail::pipeable
 //! @{
 
 template <typename T>
-auto alternative = detail::alternative_t<T>{};
+inline auto alternative = detail::alternative_t<T>{};
 
 //! @}
 

--- a/lager/lenses/variant.hpp
+++ b/lager/lenses/variant.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <lager/util.hpp>
+#include <zug/compose.hpp>
+
 #include <optional>
 #include <utility>
 #include <variant>
-
-#include <lager/util.hpp>
-#include <zug/compose.hpp>
 
 namespace lager {
 namespace lenses {

--- a/test/lenses.cpp
+++ b/test/lenses.cpp
@@ -22,6 +22,7 @@
 #include <lager/lenses/attr.hpp>
 #include <lager/lenses/optional.hpp>
 #include <lager/lenses/variant.hpp>
+#include <lager/lenses/tuple.hpp>
 
 struct yearday
 {
@@ -418,4 +419,192 @@ TEST_CASE("lenses, bind_opt")
         CHECK(view(first_first, v1) == 42);
         CHECK(view(first_first, set(first_first, v1, 256)) == 256);
     }
+}
+
+TEST_CASE("lenses::zip pair", "[lenses][zip][pair]")
+{
+    struct foo
+    {
+        int bar;
+    };
+
+    std::pair<foo, int> baz{{42}, 256};
+    auto zipped = zip(attr(&foo::bar), lager::identity);
+
+    baz = over(zipped, baz, [](auto x) {
+        return std::pair{x.second, x.first};
+    });
+
+    CHECK(baz.first.bar == 256);
+    CHECK(baz.second == 42);
+}
+
+TEST_CASE("lenses::zip tuple", "[lenses][zip][tuple]")
+{
+    struct foo
+    {
+        int bar;
+    };
+    struct bar
+    {
+        foo foo;
+    };
+
+    std::tuple<foo, bar, int> baz{{42}, {{1115}}, 256};
+
+    auto zipped = zip(
+        attr(&foo::bar), attr(&bar::foo) | attr(&foo::bar), lager::identity);
+
+    baz = over(zipped, baz, [](auto x) {
+        auto [a, b, c] = x;
+        return std::tuple{b, c, a};
+    });
+
+    CHECK(view(zipped, baz) == std::tuple(1115, 256, 42));
+}
+
+TEST_CASE("lenses::explode", "[lenses][explode]")
+{
+    struct foo
+    {
+        int value;
+    };
+    struct bar
+    {
+        foo foo;
+        int value;
+    };
+
+    auto baz = bar{{42}, 256};
+
+    auto exploded =
+        lenses::explode(attr(&bar::foo) | attr(&foo::value), attr(&bar::value));
+
+    baz = over(exploded, baz, [](auto x) {
+        auto [a, b] = x;
+        return std::tuple{b, a};
+    });
+
+    CHECK(view(exploded, baz) == std::tuple(256, 42));
+}
+
+TEST_CASE("lenses::explode use after move edge case", "[lenses][explode]")
+{
+    using std::string;
+
+    struct foo
+    {
+        string value;
+    };
+    struct bar
+    {
+        foo foo;
+        string value;
+    };
+
+    auto baz = bar{{"42"}, "256"};
+
+    auto exploded =
+        lenses::explode(attr(&bar::foo) | attr(&foo::value), attr(&bar::value));
+
+    baz = over(exploded, std::move(baz), [](auto x) {
+        auto [a, b] = x;
+        return std::tuple{b, a};
+    });
+
+    CHECK(view(exploded, baz) == std::tuple("256", "42"));
+    CHECK(view(exploded, std::move(baz)) == std::tuple("256", "42"));
+}
+
+TEST_CASE("lenses::explode composed with lenses::zip", "[lenses][explode][zip]")
+{
+    struct foo
+    {
+        int value;
+    };
+    struct bar
+    {
+        foo foo;
+        int value;
+    };
+
+    auto baz = bar{{42}, 256};
+
+    auto exploded = lenses::explode(attr(&bar::foo), attr(&bar::value));
+    auto zipped   = lenses::zip(attr(&foo::value), lager::identity);
+
+    baz = over(exploded | zipped, baz, [](auto x) {
+        auto [a, b] = x;
+        return std::tuple{b, a};
+    });
+
+    CHECK(view(exploded | zipped, baz) == std::tuple(256, 42));
+}
+
+TEST_CASE("lenses::attr multiple", "[lenses][attr][explode]")
+{
+    struct foo
+    {
+        int value;
+    };
+    struct bar
+    {
+        foo foo;
+        int value;
+    };
+
+    auto baz = bar{{42}, 256};
+
+    auto exploded = lenses::attr(&bar::foo, &bar::value);
+    auto zipped   = lenses::zip(attr(&foo::value), lager::identity);
+
+    baz = over(exploded | zipped, baz, [](auto x) {
+        auto [a, b] = x;
+        return std::tuple{b, a};
+    });
+
+    CHECK(view(exploded | zipped, baz) == std::tuple(256, 42));
+}
+
+auto inline increment = [](auto x) { return x + 1; };
+
+TEST_CASE("lenses::element tuple", "[lenses][element][tuple]")
+{
+    std::tuple<int, int, int> foo{1, 2, 3};
+
+    CHECK(view(element<0>, foo) == 1);
+    CHECK(view(element<1>, foo) == 2);
+    CHECK(view(element<2>, foo) == 3);
+
+    CHECK(view(first, foo) == 1);
+    CHECK(view(second, foo) == 2);
+
+    CHECK(over(element<1>, foo, increment) == std::tuple{1, 3, 3});
+}
+
+TEST_CASE("lenses::element pair", "[lenses][element][pair]")
+{
+    std::pair<int, int> foo{1, 2};
+
+    CHECK(view(element<0>, foo) == 1);
+    CHECK(view(element<1>, foo) == 2);
+
+    CHECK(view(first, foo) == 1);
+    CHECK(view(second, foo) == 2);
+
+    CHECK(over(element<1>, foo, increment) == std::pair{1, 3});
+}
+
+TEST_CASE("lenses::element array", "[lenses][element][array]")
+{
+    std::array<int, 3> foo{1, 2, 3};
+
+    CHECK(view(element<0>, foo) == 1);
+    CHECK(view(element<1>, foo) == 2);
+    CHECK(view(element<2>, foo) == 3);
+
+    CHECK(view(first, foo) == 1);
+    CHECK(view(second, foo) == 2);
+
+    CHECK(over(element<1>, foo, increment) == std::array{1, 3, 3});
 }

--- a/test/lenses.cpp
+++ b/test/lenses.cpp
@@ -463,7 +463,7 @@ TEST_CASE("lenses::zip tuple", "[lenses][zip][tuple]")
     CHECK(view(zipped, baz) == std::tuple(1115, 256, 42));
 }
 
-TEST_CASE("lenses::explode", "[lenses][explode]")
+TEST_CASE("lenses::fan", "[lenses][fan]")
 {
     struct foo
     {
@@ -478,7 +478,7 @@ TEST_CASE("lenses::explode", "[lenses][explode]")
     auto baz = bar{{42}, 256};
 
     auto exploded =
-        lenses::explode(attr(&bar::f) | attr(&foo::value), attr(&bar::value));
+        lenses::fan(attr(&bar::f) | attr(&foo::value), attr(&bar::value));
 
     baz = over(exploded, baz, [](auto x) {
         auto [a, b] = x;
@@ -488,7 +488,7 @@ TEST_CASE("lenses::explode", "[lenses][explode]")
     CHECK(view(exploded, baz) == std::tuple(256, 42));
 }
 
-TEST_CASE("lenses::explode use after move edge case", "[lenses][explode]")
+TEST_CASE("lenses::fan use after move edge case", "[lenses][fan]")
 {
     using std::string;
 
@@ -505,7 +505,7 @@ TEST_CASE("lenses::explode use after move edge case", "[lenses][explode]")
     auto baz = bar{{"42"}, "256"};
 
     auto exploded =
-        lenses::explode(attr(&bar::f) | attr(&foo::value), attr(&bar::value));
+        lenses::fan(attr(&bar::f) | attr(&foo::value), attr(&bar::value));
 
     baz = over(exploded, std::move(baz), [](auto x) {
         auto [a, b] = x;
@@ -516,7 +516,7 @@ TEST_CASE("lenses::explode use after move edge case", "[lenses][explode]")
     CHECK(view(exploded, std::move(baz)) == std::tuple("256", "42"));
 }
 
-TEST_CASE("lenses::explode composed with lenses::zip", "[lenses][explode][zip]")
+TEST_CASE("lenses::fan composed with lenses::zip", "[lenses][fan][zip]")
 {
     struct foo
     {
@@ -530,7 +530,7 @@ TEST_CASE("lenses::explode composed with lenses::zip", "[lenses][explode][zip]")
 
     auto baz = bar{{42}, 256};
 
-    auto exploded = lenses::explode(attr(&bar::f), attr(&bar::value));
+    auto exploded = lenses::fan(attr(&bar::f), attr(&bar::value));
     auto zipped   = lenses::zip(attr(&foo::value), lager::identity);
 
     baz = over(exploded | zipped, baz, [](auto x) {
@@ -541,7 +541,7 @@ TEST_CASE("lenses::explode composed with lenses::zip", "[lenses][explode][zip]")
     CHECK(view(exploded | zipped, baz) == std::tuple(256, 42));
 }
 
-TEST_CASE("lenses::attr multiple", "[lenses][attr][explode]")
+TEST_CASE("lenses::attr multiple", "[lenses][attr][fan]")
 {
     struct foo
     {

--- a/test/lenses.cpp
+++ b/test/lenses.cpp
@@ -425,17 +425,17 @@ TEST_CASE("lenses::zip pair", "[lenses][zip][pair]")
 {
     struct foo
     {
-        int bar;
+        int value;
     };
 
     std::pair<foo, int> baz{{42}, 256};
-    auto zipped = zip(attr(&foo::bar), lager::identity);
+    auto zipped = zip(attr(&foo::value), lager::identity);
 
     baz = over(zipped, baz, [](auto x) {
         return std::pair{x.second, x.first};
     });
 
-    CHECK(baz.first.bar == 256);
+    CHECK(baz.first.value == 256);
     CHECK(baz.second == 42);
 }
 
@@ -443,17 +443,17 @@ TEST_CASE("lenses::zip tuple", "[lenses][zip][tuple]")
 {
     struct foo
     {
-        int bar;
+        int value;
     };
     struct bar
     {
-        foo foo;
+        foo f;
     };
 
     std::tuple<foo, bar, int> baz{{42}, {{1115}}, 256};
 
     auto zipped = zip(
-        attr(&foo::bar), attr(&bar::foo) | attr(&foo::bar), lager::identity);
+        attr(&foo::value), attr(&bar::f) | attr(&foo::value), lager::identity);
 
     baz = over(zipped, baz, [](auto x) {
         auto [a, b, c] = x;
@@ -471,14 +471,14 @@ TEST_CASE("lenses::explode", "[lenses][explode]")
     };
     struct bar
     {
-        foo foo;
+        foo f;
         int value;
     };
 
     auto baz = bar{{42}, 256};
 
     auto exploded =
-        lenses::explode(attr(&bar::foo) | attr(&foo::value), attr(&bar::value));
+        lenses::explode(attr(&bar::f) | attr(&foo::value), attr(&bar::value));
 
     baz = over(exploded, baz, [](auto x) {
         auto [a, b] = x;
@@ -498,14 +498,14 @@ TEST_CASE("lenses::explode use after move edge case", "[lenses][explode]")
     };
     struct bar
     {
-        foo foo;
+        foo f;
         string value;
     };
 
     auto baz = bar{{"42"}, "256"};
 
     auto exploded =
-        lenses::explode(attr(&bar::foo) | attr(&foo::value), attr(&bar::value));
+        lenses::explode(attr(&bar::f) | attr(&foo::value), attr(&bar::value));
 
     baz = over(exploded, std::move(baz), [](auto x) {
         auto [a, b] = x;
@@ -524,13 +524,13 @@ TEST_CASE("lenses::explode composed with lenses::zip", "[lenses][explode][zip]")
     };
     struct bar
     {
-        foo foo;
+        foo f;
         int value;
     };
 
     auto baz = bar{{42}, 256};
 
-    auto exploded = lenses::explode(attr(&bar::foo), attr(&bar::value));
+    auto exploded = lenses::explode(attr(&bar::f), attr(&bar::value));
     auto zipped   = lenses::zip(attr(&foo::value), lager::identity);
 
     baz = over(exploded | zipped, baz, [](auto x) {
@@ -549,13 +549,13 @@ TEST_CASE("lenses::attr multiple", "[lenses][attr][explode]")
     };
     struct bar
     {
-        foo foo;
+        foo f;
         int value;
     };
 
     auto baz = bar{{42}, 256};
 
-    auto exploded = lenses::attr(&bar::foo, &bar::value);
+    auto exploded = lenses::attr(&bar::f, &bar::value);
     auto zipped   = lenses::zip(attr(&foo::value), lager::identity);
 
     baz = over(exploded | zipped, baz, [](auto x) {
@@ -579,7 +579,7 @@ TEST_CASE("lenses::element tuple", "[lenses][element][tuple]")
     CHECK(view(first, foo) == 1);
     CHECK(view(second, foo) == 2);
 
-    CHECK(over(element<1>, foo, increment) == std::tuple{1, 3, 3});
+    CHECK(over(element<1>, foo, increment) == std::tuple(1, 3, 3));
 }
 
 TEST_CASE("lenses::element pair", "[lenses][element][pair]")
@@ -592,7 +592,7 @@ TEST_CASE("lenses::element pair", "[lenses][element][pair]")
     CHECK(view(first, foo) == 1);
     CHECK(view(second, foo) == 2);
 
-    CHECK(over(element<1>, foo, increment) == std::pair{1, 3});
+    CHECK(over(element<1>, foo, increment) == std::pair(1, 3));
 }
 
 TEST_CASE("lenses::element array", "[lenses][element][array]")
@@ -606,5 +606,5 @@ TEST_CASE("lenses::element array", "[lenses][element][array]")
     CHECK(view(first, foo) == 1);
     CHECK(view(second, foo) == 2);
 
-    CHECK(over(element<1>, foo, increment) == std::array{1, 3, 3});
+    CHECK(over(element<1>, foo, increment) == (std::array{1, 3, 3}));
 }


### PR DESCRIPTION
This branch introduces four new lens generators for working with tuples:
* `zip` aka: `Lens<W1, P1>, ..., Lens<Wn, Pn> -> Lens<(W1, ..., Wn), (P1, ..., Pn)>`
* `fan` aka: `Lens<W, P1>, ..., Lens<W, Pn> -> Lens<W, (P1, ..., Pn)>`
* `attr` with multiple non-overlapping members
* `element<N>`, `first` and `second`, for accessing the Nth element of a tuple-like value.