### PR TITLE
Fix list of child nodes shrinking during iteration (issue #62)

### DIFF
--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -111,6 +111,21 @@ auto has_changed(const T&, const T&)
     return true;
 }
 
+struct notifying_guard_t
+{
+    notifying_guard_t(bool& target)
+        : value_{target}
+        , target_{target}
+    {
+        target_ = true;
+    }
+
+    ~notifying_guard_t() { target_ = value_; }
+
+    bool value_;
+    bool& target_;
+};
+
 /*!
  * Base class for the various node types.  Provides basic
  * functionality for setting values and propagating them to children.
@@ -118,21 +133,6 @@ auto has_changed(const T&, const T&)
 template <typename T>
 class reader_node : public reader_node_base
 {
-    struct notifying_guard_t
-    {
-        notifying_guard_t(bool& target)
-            : value_{target}
-            , target_{target}
-        {
-            target_ = true;
-        }
-        
-        ~notifying_guard_t() { target_ = value_; }
-
-        bool value_;
-        bool& target_;
-    };
-
 public:
     using value_type  = T;
     using signal_type = signal<const value_type&>;

--- a/test/cursor.cpp
+++ b/test/cursor.cpp
@@ -178,7 +178,7 @@ TEST_CASE("automatic_tag edge case")
 
     lager::state<vec_t, lager::automatic_tag> st;
     std::vector<cur_t> cursors;
-    spy_t spy;
+    auto spy = testing::spy();
 
     st.watch([&](vec_t const& vec) {
         cursors.clear();

--- a/test/cursor.cpp
+++ b/test/cursor.cpp
@@ -197,4 +197,6 @@ TEST_CASE("automatic_tag edge case")
     });
 
     cur.set(42); // this would cause a crash before commit aefd37b
+
+    st.set(vec_t{1, 2, 3, 4}); // this will collect garbage
 }


### PR DESCRIPTION
See issue #62.

I opted for the stateful approach. This fix might not be completely exhaustive, as discussed before, but it will at least stop this particular crash from happening in some projects.

We still advise against using the `lager::automatic_tag` for most cases.