### PR TITLE
add missing includes

### DIFF
--- a/lager/event_loop/boost_asio.hpp
+++ b/lager/event_loop/boost_asio.hpp
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <thread>
+#include <utility>
 
 namespace lager {
 

--- a/lager/event_loop/manual.hpp
+++ b/lager/event_loop/manual.hpp
@@ -13,6 +13,8 @@
 #pragma once
 
 #include <functional>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace lager {

--- a/lager/event_loop/qml.hpp
+++ b/lager/event_loop/qml.hpp
@@ -4,6 +4,11 @@
 
 #include <QQuickItem>
 
+#include <functional>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
 namespace lager {
 
 class event_loop_quick_item : public QQuickItem

--- a/lager/event_loop/qt.hpp
+++ b/lager/event_loop/qt.hpp
@@ -17,6 +17,7 @@
 #include <QtConcurrent>
 
 #include <functional>
+#include <stdexcept>
 #include <utility>
 
 namespace lager {
@@ -24,11 +25,10 @@ namespace lager {
 struct with_qt_event_loop
 {
     std::reference_wrapper<QObject> obj;
-    std::reference_wrapper<QThreadPool> thread_pool = *QThreadPool::globalInstance();
+    std::reference_wrapper<QThreadPool> thread_pool =
+        *QThreadPool::globalInstance();
 
-    ~with_qt_event_loop() {
-        thread_pool.get().waitForDone();
-    }
+    ~with_qt_event_loop() { thread_pool.get().waitForDone(); }
 
     template <typename Fn>
     void async(Fn&& fn)

--- a/lager/event_loop/queue.hpp
+++ b/lager/event_loop/queue.hpp
@@ -12,7 +12,10 @@
 
 #pragma once
 
+#include <functional>
+#include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace lager {
 

--- a/lager/event_loop/sdl.hpp
+++ b/lager/event_loop/sdl.hpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <atomic>
 #include <functional>
+#include <stdexcept>
+#include <utility>
 
 #include <cassert>
 #include <cstddef>


### PR DESCRIPTION
When compiling with clang-9 I got this error:
```
..../lager/lager/event_loop/manual.hpp:25:31: error: expected ';' after
      expression
        throw std::logic_error{"manual_event_loop does not support async()"};
```
adding
```
#include <stdexcept>
```
in manual.hpp fixed the problem.
Then i moved on and added missing includes to all header files inside the event_loop folder :smile: .

