### PR TITLE
Prevent compiler from treating cursor as template in debugger.hpp

### DIFF
--- a/lager/debug/debugger.hpp
+++ b/lager/debug/debugger.hpp
@@ -136,7 +136,7 @@ struct debugger
                     return {m, noop};
                 },
                 [&](redo_action) -> result_t {
-                    if (m.cursor < m.history.size())
+                    if ((m.cursor) < m.history.size())
                         ++m.cursor;
                     return {m, noop};
                 },


### PR DESCRIPTION
If we include cursor.hpp before debugger.hpp, the compiler will think `cursor` is a template in the expression `m.cursor < m.history.size()` and refuse to compile correctly.
This PR fixes this problem.

```bash
] echo -e '#include <lager/cursor.hpp>\n#include <lager/debug/debugger.hpp>\nint main(){}' > dummy.cpp
] c++ -I<*omitted*> -std=c++17 dummy.cpp
In file included from dummy.cpp:2:
./lager/debug/debugger.hpp: In lambda function:
./lager/debug/debugger.hpp:139:51: error: type/value mismatch at argument 1 in template parameter list for ‘template<class T> class lager::cursor’
  139 |                     if (m.cursor < m.history.size())
      |                                                   ^
./lager/debug/debugger.hpp:139:51: note:   expected a type, got ‘m.history.size()’
```