### PR TITLE
Update store.hpp

### DIFF
--- a/lager/store.hpp
+++ b/lager/store.hpp
@@ -135,7 +135,7 @@ private:
 
         void dispatch(action_t action) override
         {
-            loop.post([=] {
+            loop.post([this, =] {
                 base_t::push_down(invoke_reducer<deps_t>(
                     reducer,
                     base_t::current(),


### PR DESCRIPTION
This fixes a warning in the store header when compiling with C++20 enabled.

The `this` capture with `=` has been deprecated, so we must specify `this` manually to avoid the warning and the potential breakage in the future.