### PR TITLE
Add a missing include in detail/nodes.hpp

### DIFF
--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -44,6 +44,7 @@
 #include <zug/meta/pack.hpp>
 #include <zug/tuplify.hpp>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
In one of our projects @ Globus Medical I have a compilation error that `remove_if` (line 225) is an unknown identifier.