### PR TITLE
Make reducers optional to make_store

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -344,7 +344,6 @@ procedure of our application:
    {
        auto store = lager::make_store<counter::action>(
            model{},
-           update,
            lager::with_manual_event_loop{});
        watch(store, draw);
 

--- a/doc/cursors.rst
+++ b/doc/cursors.rst
@@ -127,7 +127,7 @@ as the "single source of truth" for other cursors.
      #include <lager/store.hpp>
 
      auto store = lager::make_store<action>(
-         model, update, event_loop, enhancers...);
+         model, event_loop, enhancers...);
 
 * ``lager::sensor`` is a subclass of ``lager::reader``.
   It takes a function and use its result as the value of
@@ -346,7 +346,7 @@ reducers:
    using house_action = std::variant<change_room_action,
                                      add_room_action>;
 
-   house update_house(house h, house_action a)
+   house update(house h, house_action a)
    {
        return std::visit(lager::visitor{
            [&](change_room_action a) {
@@ -391,7 +391,6 @@ Here, we will use ``lager::store`` as an example.
 
    auto store = lager::make_store<house_action>(
        initial_house,
-       &update_house,
        // Be sure to use a suitable event loop
        // that integrates into the rest of your program
        lager::with_manual_event_loop{});

--- a/doc/modularity.rst
+++ b/doc/modularity.rst
@@ -365,7 +365,7 @@ It would be nice, however, if we could write instead:
 
    auto store = lager::make_store<doc_action>(
        doc_model,
-       update_doc,
+       lager::with_reducer(update_doc),
        with_history);
 
 We can indeed write such a ``with_history`` construction, my using the

--- a/example/autopong/sdl2/main.cpp
+++ b/example/autopong/sdl2/main.cpp
@@ -151,7 +151,6 @@ int main(int argc, const char** argv)
     auto loop = lager::sdl_event_loop{};
     auto store =
         lager::make_store<autopong::action>(autopong::model{},
-                                            autopong::update,
                                             lager::with_sdl_event_loop{loop},
 #ifdef DEBUGGER
                                             lager::with_debugger(debugger)

--- a/example/counter/ncurses/main.cpp
+++ b/example/counter/ncurses/main.cpp
@@ -71,7 +71,6 @@ int main(int argc, const char** argv)
 #endif
     auto store = lager::make_store<counter::action>(
         counter::model{},
-        counter::update,
         lager::with_boost_asio_event_loop{serv.get_executor()},
         zug::comp(
 #ifdef DEBUGGER

--- a/example/counter/sdl2/main.cpp
+++ b/example/counter/sdl2/main.cpp
@@ -94,7 +94,7 @@ int main()
     auto view  = sdl_view{};
     auto loop  = lager::sdl_event_loop{};
     auto store = lager::make_store<counter::action>(
-        counter::model{}, counter::update, lager::with_sdl_event_loop{loop});
+        counter::model{}, lager::with_sdl_event_loop{loop});
 
     watch(store, [&](auto&& val) { draw(view, val); });
     draw(view, store.get());

--- a/example/counter/std/main.cpp
+++ b/example/counter/std/main.cpp
@@ -37,7 +37,7 @@ std::optional<counter::action> intent(char event)
 int main()
 {
     auto store = lager::make_store<counter::action>(
-        counter::model{}, counter::update, lager::with_manual_event_loop{});
+        counter::model{}, lager::with_manual_event_loop{});
     watch(store, draw);
 
     auto event = char{};

--- a/example/snake/qml/main.cpp
+++ b/example/snake/qml/main.cpp
@@ -32,8 +32,8 @@ int main(int argc, char** argv)
 
     std::random_device rd;
     auto initial_state = make_initial(rd());
-    auto store         = lager::make_store<action_t>(
-        std::move(initial_state), update, lager::with_qt_event_loop{app});
+    auto store         = lager::make_store<action_t>(std::move(initial_state),
+                                             lager::with_qt_event_loop{app});
 
     Game game{store};
     watch(store, [&](auto&& state) { game.setModel(state.game); });

--- a/example/todo/imgui/main.cpp
+++ b/example/todo/imgui/main.cpp
@@ -157,7 +157,7 @@ int main()
 
     auto loop  = lager::sdl_event_loop{};
     auto store = lager::make_store<todo::action>(
-        todo::model{}, todo::update, lager::with_sdl_event_loop{loop});
+        todo::model{}, lager::with_sdl_event_loop{loop});
     auto state = ui_state{};
 
     loop.run(

--- a/test/event_loop/boost_asio.cpp
+++ b/test/event_loop/boost_asio.cpp
@@ -22,7 +22,6 @@ TEST_CASE("basic")
     auto ctx   = boost::asio::io_context{};
     auto store = lager::make_store<counter::action>(
         counter::model{},
-        counter::update,
         lager::with_boost_asio_event_loop{ctx.get_executor()});
     store.dispatch(counter::increment_action{});
     ctx.run();
@@ -34,9 +33,7 @@ TEST_CASE("strand")
     auto ctx    = boost::asio::io_context{};
     auto strand = boost::asio::io_context::strand{ctx};
     auto store  = lager::make_store<counter::action>(
-        counter::model{},
-        counter::update,
-        lager::with_boost_asio_event_loop{strand});
+        counter::model{}, lager::with_boost_asio_event_loop{strand});
     store.dispatch(counter::increment_action{});
     ctx.run();
     CHECK(store->value == 1);
@@ -48,9 +45,7 @@ TEST_CASE("modern strand")
     auto strand = boost::asio::strand<boost::asio::io_context::executor_type>{
         ctx.get_executor()};
     auto store = lager::make_store<counter::action>(
-        counter::model{},
-        counter::update,
-        lager::with_boost_asio_event_loop{strand});
+        counter::model{}, lager::with_boost_asio_event_loop{strand});
     store.dispatch(counter::increment_action{});
     ctx.run();
     CHECK(store->value == 1);

--- a/test/event_loop/qml.cpp
+++ b/test/event_loop/qml.cpp
@@ -26,9 +26,7 @@ class TestApp : public lager::event_loop_quick_item
 
     store_t store_ =
         lager::make_store<counter::action, lager::transactional_tag>(
-            counter::model{},
-            counter::update,
-            lager::with_qml_event_loop{*this});
+            counter::model{}, lager::with_qml_event_loop{*this});
 
 public:
     TestApp(QQuickItem* parent = nullptr)

--- a/test/event_loop/qt.cpp
+++ b/test/event_loop/qt.cpp
@@ -105,7 +105,7 @@ TEST_CASE("global thread pool")
     int argc = 0;
     QCoreApplication app{argc, nullptr};
     auto store = lager::make_store<loop::action>(
-        loop::model{}, loop::update, lager::with_qt_event_loop{app});
+        loop::model{}, lager::with_qt_event_loop{app});
     run_test(store, store);
 }
 
@@ -115,8 +115,6 @@ TEST_CASE("manualy defined thread pool")
     QCoreApplication app{argc, nullptr};
     QThreadPool thread_pool;
     auto store = lager::make_store<loop::action>(
-        loop::model{},
-        loop::update,
-        lager::with_qt_event_loop{app, thread_pool});
+        loop::model{}, lager::with_qt_event_loop{app, thread_pool});
     run_test(store, store);
 }

--- a/test/event_loop/queue.cpp
+++ b/test/event_loop/queue.cpp
@@ -21,7 +21,7 @@ TEST_CASE("basic")
 {
     auto queue = lager::queue_event_loop{};
     auto store = lager::make_store<counter::action>(
-        counter::model{}, counter::update, lager::with_queue_event_loop{queue});
+        counter::model{}, lager::with_queue_event_loop{queue});
 
     store.dispatch(counter::increment_action{});
     CHECK(store->value == 0);

--- a/test/event_loop/safe_queue.cpp
+++ b/test/event_loop/safe_queue.cpp
@@ -21,9 +21,7 @@ TEST_CASE("basic")
 {
     auto queue = lager::safe_queue_event_loop{};
     auto store = lager::make_store<counter::action>(
-        counter::model{},
-        counter::update,
-        lager::with_safe_queue_event_loop{queue});
+        counter::model{}, lager::with_safe_queue_event_loop{queue});
 
     store.dispatch(counter::increment_action{});
     CHECK(store->value == 0);
@@ -36,9 +34,7 @@ TEST_CASE("threads")
 {
     auto queue = lager::safe_queue_event_loop{};
     auto store = lager::make_store<counter::action>(
-        counter::model{},
-        counter::update,
-        lager::with_safe_queue_event_loop{queue});
+        counter::model{}, lager::with_safe_queue_event_loop{queue});
     auto threads = std::vector<std::thread>{};
 
     for (auto i = 0; i < 100; ++i) {

--- a/test/setter.cpp
+++ b/test/setter.cpp
@@ -20,7 +20,9 @@
 TEST_CASE("combine setter with store")
 {
     auto store = lager::make_store<int, lager::transactional_tag>(
-        0, [](int s, int a) { return a; }, lager::with_manual_event_loop{});
+        0,
+        lager::with_manual_event_loop{},
+        lager::with_reducer([](int s, int a) { return a; }));
     auto cursor =
         store.xform(zug::identity).setter([&](int x) { store.dispatch(x); });
 
@@ -45,7 +47,9 @@ TEST_CASE("combine setter with store")
 TEST_CASE("combine automatic setter with store")
 {
     auto store = lager::make_store<int, lager::transactional_tag>(
-        0, [](int s, int a) { return a; }, lager::with_manual_event_loop{});
+        0,
+        lager::with_manual_event_loop{},
+        lager::with_reducer([](int s, int a) { return a; }));
     auto cursor =
         store.xform(zug::identity).setter<lager::automatic_tag>([&](int x) {
             store.dispatch(x);


### PR DESCRIPTION
The convention is to have a reducer `update` that can be found via ADL in the model namespace.