### PR TITLE
#108: Reduce Qt MOC compilation time

### DIFF
--- a/lager/extra/qt.hpp
+++ b/lager/extra/qt.hpp
@@ -12,9 +12,11 @@
 
 #pragma once
 
+#ifndef Q_MOC_RUN
 #include <lager/cursor.hpp>
 #include <lager/reader.hpp>
 #include <lager/watch.hpp>
+#endif
 
 namespace lager {
 


### PR DESCRIPTION
The Qt MOC compiler is notoriously slow when preprocessing.

In particular, each time code includes lager/extra/qt.hpp, the MOC compiler spends about four seconds on precompiling it, even though the Qt relevant code is less than 100 lines.

Simply excluding non-Qt relevant code in lager/extra/qt.hpp as follows would reduce MOC processing time to a fraction of a second:

#ifndef Q_MOC_RUN
#include <lager/cursor.hpp>
#include <lager/reader.hpp>
#include <lager/watch.hpp>
#endif