### PR TITLE
Use full SDL2 include path

### DIFF
--- a/lager/event_loop/sdl.hpp
+++ b/lager/event_loop/sdl.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 #include <algorithm>
 #include <atomic>


### PR DESCRIPTION
Should the `SDL.h` include path be replaced with `SDL2/SDL.h`?