### PR TITLE
Struct derive macros

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,6 +10,7 @@ cc_library(
         "@boost//:intrusive",
         "@boost//:intrusive_ptr",
         "@zug//:zug",
+        "@cereal//:cereal",
     ],
     includes = [".", "lager/"],
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,5 +10,11 @@ git_repository(
     remote = "https://github.com/arximboldi/zug",
 )
 
+git_repository(
+    name = "cereal",
+    commit = "72d3eb200dc0568277255f960bc2bd7eccf8bafc",
+    remote = "https://github.com/USCiLab/cereal",
+)
+
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 boost_deps()

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -32,7 +32,7 @@
         LAGER_DERIVE_ITER__,                                                   \
         BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
         BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))))             \
-    static_assert("force semicolon")
+    static_assert(true, "force semicolon")
 
 #define LAGER_DERIVE_TEMPLATE_ITER__(r__, data__, elem__)                      \
     BOOST_PP_CAT(LAGER_DERIVE_TEMPLATE_IMPL_, elem__)                          \
@@ -47,7 +47,7 @@
         LAGER_DERIVE_TEMPLATE_ITER__,                                          \
         BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
         BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))));            \
-    static_assert("force semicolon")
+    static_assert(true, "force semicolon")
 
 #define LAGER_DERIVE_NESTED_ITER__(r__, data__, elem__)                        \
     BOOST_PP_CAT(LAGER_DERIVE_NESTED_IMPL_, elem__)                            \
@@ -58,4 +58,4 @@
         LAGER_DERIVE_NESTED_ITER__,                                            \
         BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
         BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))))             \
-    static_assert("force semicolon")
+    static_assert(true, "force semicolon")

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -27,29 +27,49 @@
 
 #define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, elem__) &&a.elem__ == b.elem__
 
-#define LAGER_DERIVE_IMPL_EQ(r__, ns__, name__, members__)                     \
+#define LAGER_DERIVE_IMPL_EQ(r__, tpl__, ns__, name__, members__)              \
     namespace ns__ {                                                           \
-    inline bool operator==(name__ const& a, name__ const& b)                   \
+    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
+    inline bool operator==(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
+                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
     {                                                                          \
         return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
             r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
     }                                                                          \
-    inline bool operator!=(name__ const& a, name__ const& b)                   \
+    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
+    inline bool operator!=(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
+                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
     {                                                                          \
         return !(a == b);                                                      \
     }                                                                          \
     }
 
 #define LAGER_DERIVE_ITER__(r__, data__, elem__)                               \
-    BOOST_PP_EXPAND(BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)(                  \
-        r__,                                                                   \
-        BOOST_PP_SEQ_ELEM(0, data__),                                          \
-        BOOST_PP_SEQ_ELEM(1, data__),                                          \
-        BOOST_PP_EXPAND(BOOST_PP_SEQ_REST_N(2, data__))))
+    BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)                                   \
+    (r__,                                                                      \
+     (),                                                                       \
+     BOOST_PP_SEQ_ELEM(0, data__),                                             \
+     BOOST_PP_SEQ_ELEM(1, data__),                                             \
+     BOOST_PP_SEQ_REST_N(2, data__))
 
 #define LAGER_DERIVE(impls__, ...)                                             \
     BOOST_PP_LIST_FOR_EACH(                                                    \
         LAGER_DERIVE_ITER__,                                                   \
+        BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
+        BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))));            \
+    static_assert("force semicolon")
+
+#define LAGER_DERIVE_TEMPLATE_ITER__(r__, data__, elem__)                      \
+    BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)                                   \
+    (r__,                                                                      \
+     (template <BOOST_PP_REMOVE_PARENS(BOOST_PP_SEQ_ELEM(1, data__))>),        \
+     BOOST_PP_SEQ_ELEM(0, data__),                                             \
+     BOOST_PP_SEQ_ELEM(2, data__),                                             \
+     BOOST_PP_SEQ_REST_N(3, data__))
+
+#define LAGER_DERIVE_TEMPLATE(impls__, ...)                                    \
+    BOOST_PP_LIST_FOR_EACH(                                                    \
+        LAGER_DERIVE_TEMPLATE_ITER__,                                          \
         BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
         BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))));            \
     static_assert("force semicolon")

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -42,7 +42,20 @@
     {                                                                          \
         return !(a == b);                                                      \
     }                                                                          \
-    }
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_IMPL_NESTED_EQ(r__, name__, members__)                    \
+    friend bool operator==(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
+            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
+    }                                                                          \
+    friend bool operator!=(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return !(a == b);                                                      \
+    }                                                                          \
+    //
 
 #define LAGER_DERIVE_ITER__(r__, data__, elem__)                               \
     BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)                                   \
@@ -56,7 +69,7 @@
     BOOST_PP_LIST_FOR_EACH(                                                    \
         LAGER_DERIVE_ITER__,                                                   \
         BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
-        BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))));            \
+        BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))))             \
     static_assert("force semicolon")
 
 #define LAGER_DERIVE_TEMPLATE_ITER__(r__, data__, elem__)                      \
@@ -72,4 +85,15 @@
         LAGER_DERIVE_TEMPLATE_ITER__,                                          \
         BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
         BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))));            \
+    static_assert("force semicolon")
+
+#define LAGER_DERIVE_NESTED_ITER__(r__, data__, elem__)                        \
+    BOOST_PP_CAT(LAGER_DERIVE_IMPL_NESTED_, elem__)                            \
+    (r__, BOOST_PP_SEQ_ELEM(0, data__), BOOST_PP_SEQ_REST_N(1, data__))
+
+#define LAGER_DERIVE_NESTED(impls__, ...)                                      \
+    BOOST_PP_LIST_FOR_EACH(                                                    \
+        LAGER_DERIVE_NESTED_ITER__,                                            \
+        BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
+        BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))))             \
     static_assert("force semicolon")

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -23,7 +23,6 @@
 #define LAGER_DERIVE_ITER__(r__, data__, elem__)                               \
     BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)                                   \
     (r__,                                                                      \
-     (),                                                                       \
      BOOST_PP_SEQ_ELEM(0, data__),                                             \
      BOOST_PP_SEQ_ELEM(1, data__),                                             \
      BOOST_PP_SEQ_REST_N(2, data__))
@@ -36,10 +35,10 @@
     static_assert("force semicolon")
 
 #define LAGER_DERIVE_TEMPLATE_ITER__(r__, data__, elem__)                      \
-    BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)                                   \
+    BOOST_PP_CAT(LAGER_DERIVE_TEMPLATE_IMPL_, elem__)                          \
     (r__,                                                                      \
-     (template <BOOST_PP_REMOVE_PARENS(BOOST_PP_SEQ_ELEM(1, data__))>),        \
      BOOST_PP_SEQ_ELEM(0, data__),                                             \
+     BOOST_PP_SEQ_ELEM(1, data__),                                             \
      BOOST_PP_SEQ_ELEM(2, data__),                                             \
      BOOST_PP_SEQ_REST_N(3, data__))
 
@@ -51,7 +50,7 @@
     static_assert("force semicolon")
 
 #define LAGER_DERIVE_NESTED_ITER__(r__, data__, elem__)                        \
-    BOOST_PP_CAT(LAGER_DERIVE_IMPL_NESTED_, elem__)                            \
+    BOOST_PP_CAT(LAGER_DERIVE_NESTED_IMPL_, elem__)                            \
     (r__, BOOST_PP_SEQ_ELEM(0, data__), BOOST_PP_SEQ_REST_N(1, data__))
 
 #define LAGER_DERIVE_NESTED(impls__, ...)                                      \

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -16,21 +16,22 @@
 #include <boost/preprocessor/control/expr_if.hpp>
 #include <boost/preprocessor/expand.hpp>
 #include <boost/preprocessor/list/for_each.hpp>
+#include <boost/preprocessor/punctuation/remove_parens.hpp>
+#include <boost/preprocessor/seq/elem.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
-#include <boost/preprocessor/tuple/elem.hpp>
-#include <boost/preprocessor/tuple/pop_front.hpp>
+#include <boost/preprocessor/seq/rest_n.hpp>
+#include <boost/preprocessor/seq/seq.hpp>
 #include <boost/preprocessor/tuple/to_list.hpp>
 #include <boost/preprocessor/tuple/to_seq.hpp>
 
-#define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, i__, elem__)                  \
-    BOOST_PP_EXPR_IF(i__, &&)                                                  \
-    a.elem__ == b.elem__
+#define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, elem__) &&a.elem__ == b.elem__
 
 #define LAGER_DERIVE_IMPL_EQ(r__, ns__, name__, members__)                     \
     namespace ns__ {                                                           \
     inline bool operator==(name__ const& a, name__ const& b)                   \
     {                                                                          \
-        return BOOST_PP_SEQ_FOR_EACH_I_R(                                      \
+        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
             r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
     }                                                                          \
     inline bool operator!=(name__ const& a, name__ const& b)                   \
@@ -42,12 +43,13 @@
 #define LAGER_DERIVE_ITER__(r__, data__, elem__)                               \
     BOOST_PP_EXPAND(BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)(                  \
         r__,                                                                   \
-        BOOST_PP_TUPLE_ELEM(0, data__),                                        \
-        BOOST_PP_TUPLE_ELEM(1, data__),                                        \
-        BOOST_PP_EXPAND(BOOST_PP_TUPLE_TO_SEQ(                                 \
-            BOOST_PP_TUPLE_POP_FRONT(BOOST_PP_TUPLE_POP_FRONT(data__))))))
+        BOOST_PP_SEQ_ELEM(0, data__),                                          \
+        BOOST_PP_SEQ_ELEM(1, data__),                                          \
+        BOOST_PP_EXPAND(BOOST_PP_SEQ_REST_N(2, data__))))
 
 #define LAGER_DERIVE(impls__, ...)                                             \
     BOOST_PP_LIST_FOR_EACH(                                                    \
-        LAGER_DERIVE_ITER__, (__VA_ARGS__), BOOST_PP_TUPLE_TO_LIST(impls__));  \
+        LAGER_DERIVE_ITER__,                                                   \
+        BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)),                                  \
+        BOOST_PP_TUPLE_TO_LIST((BOOST_PP_REMOVE_PARENS(impls__))));            \
     static_assert("force semicolon")

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -13,49 +13,12 @@
 #pragma once
 
 #include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/control/expr_if.hpp>
-#include <boost/preprocessor/expand.hpp>
 #include <boost/preprocessor/list/for_each.hpp>
 #include <boost/preprocessor/punctuation/remove_parens.hpp>
 #include <boost/preprocessor/seq/elem.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
-#include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/seq/rest_n.hpp>
-#include <boost/preprocessor/seq/seq.hpp>
 #include <boost/preprocessor/tuple/to_list.hpp>
 #include <boost/preprocessor/tuple/to_seq.hpp>
-
-#define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, elem__) &&a.elem__ == b.elem__
-
-#define LAGER_DERIVE_IMPL_EQ(r__, tpl__, ns__, name__, members__)              \
-    namespace ns__ {                                                           \
-    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
-    inline bool operator==(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
-                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
-    {                                                                          \
-        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
-            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
-    }                                                                          \
-    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
-    inline bool operator!=(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
-                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
-    {                                                                          \
-        return !(a == b);                                                      \
-    }                                                                          \
-    }                                                                          \
-    //
-
-#define LAGER_DERIVE_IMPL_NESTED_EQ(r__, name__, members__)                    \
-    friend bool operator==(name__ const& a, name__ const& b)                   \
-    {                                                                          \
-        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
-            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
-    }                                                                          \
-    friend bool operator!=(name__ const& a, name__ const& b)                   \
-    {                                                                          \
-        return !(a == b);                                                      \
-    }                                                                          \
-    //
 
 #define LAGER_DERIVE_ITER__(r__, data__, elem__)                               \
     BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)                                   \

--- a/lager/extra/derive.hpp
+++ b/lager/extra/derive.hpp
@@ -1,0 +1,53 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#pragma once
+
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/expand.hpp>
+#include <boost/preprocessor/list/for_each.hpp>
+#include <boost/preprocessor/seq/for_each_i.hpp>
+#include <boost/preprocessor/tuple/elem.hpp>
+#include <boost/preprocessor/tuple/pop_front.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
+#include <boost/preprocessor/tuple/to_seq.hpp>
+
+#define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, i__, elem__)                  \
+    BOOST_PP_EXPR_IF(i__, &&)                                                  \
+    a.elem__ == b.elem__
+
+#define LAGER_DERIVE_IMPL_EQ(r__, ns__, name__, members__)                     \
+    namespace ns__ {                                                           \
+    inline bool operator==(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return BOOST_PP_SEQ_FOR_EACH_I_R(                                      \
+            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
+    }                                                                          \
+    inline bool operator!=(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return !(a == b);                                                      \
+    }                                                                          \
+    }
+
+#define LAGER_DERIVE_ITER__(r__, data__, elem__)                               \
+    BOOST_PP_EXPAND(BOOST_PP_CAT(LAGER_DERIVE_IMPL_, elem__)(                  \
+        r__,                                                                   \
+        BOOST_PP_TUPLE_ELEM(0, data__),                                        \
+        BOOST_PP_TUPLE_ELEM(1, data__),                                        \
+        BOOST_PP_EXPAND(BOOST_PP_TUPLE_TO_SEQ(                                 \
+            BOOST_PP_TUPLE_POP_FRONT(BOOST_PP_TUPLE_POP_FRONT(data__))))))
+
+#define LAGER_DERIVE(impls__, ...)                                             \
+    BOOST_PP_LIST_FOR_EACH(                                                    \
+        LAGER_DERIVE_ITER__, (__VA_ARGS__), BOOST_PP_TUPLE_TO_LIST(impls__));  \
+    static_assert("force semicolon")

--- a/lager/extra/derive/cereal.hpp
+++ b/lager/extra/derive/cereal.hpp
@@ -1,0 +1,65 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#pragma once
+
+#include <cereal/cereal.hpp>
+
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/punctuation/comma_if.hpp>
+#include <boost/preprocessor/punctuation/remove_parens.hpp>
+#include <boost/preprocessor/seq/for_each_i.hpp>
+#include <boost/preprocessor/stringize.hpp>
+
+#define LAGER_DERIVE_IMPL_CEREAL_ITER__(r__, data__, i__, elem__)              \
+    BOOST_PP_COMMA_IF(i__)                                                     \
+    cereal::make_nvp(BOOST_PP_STRINGIZE(elem__), x.elem__)
+
+#define LAGER_DERIVE_IMPL_CEREAL_MEMBERS_NON_EMPTY__(r__, members__)           \
+    ar(BOOST_PP_SEQ_FOR_EACH_I_R(                                              \
+        r__, LAGER_DERIVE_IMPL_CEREAL_ITER__, _, members__));
+
+#define LAGER_DERIVE_IMPL_CEREAL_MEMBERS_EMPTY__(r__, members__)
+
+#define LAGER_DERIVE_IMPL_CEREAL_MEMBERS__(r__, members__)                     \
+    BOOST_PP_IF(BOOST_PP_SEQ_SIZE(members__),                                  \
+                LAGER_DERIVE_IMPL_CEREAL_MEMBERS_NON_EMPTY__,                  \
+                LAGER_DERIVE_IMPL_CEREAL_MEMBERS_EMPTY__)                      \
+    (r__, members__)
+
+#define LAGER_DERIVE_IMPL_CEREAL(r__, ns__, name__, members__)                 \
+    namespace ns__ {                                                           \
+    template <typename Archive>                                                \
+    void serialize(Archive& ar, name__& x)                                     \
+    {                                                                          \
+        LAGER_DERIVE_IMPL_CEREAL_MEMBERS__(r__, members__)                     \
+    }                                                                          \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_TEMPLATE_IMPL_CEREAL(r__, ns__, tpl__, name__, members__) \
+    namespace ns__ {                                                           \
+    template <typename Archive, BOOST_PP_REMOVE_PARENS(tpl__)>                 \
+    void serialize(Archive& ar, BOOST_PP_REMOVE_PARENS(name__) & x)            \
+    {                                                                          \
+        LAGER_DERIVE_IMPL_CEREAL_MEMBERS__(r__, members__)                     \
+    }                                                                          \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_NESTED_IMPL_CEREAL(r__, name__, members__)                \
+    template <typename Archive>                                                \
+    friend void serialize(Archive& ar, name__& x)                              \
+    {                                                                          \
+        LAGER_DERIVE_IMPL_CEREAL_MEMBERS__(r__, members__)                     \
+    }                                                                          \
+    //

--- a/lager/extra/derive/eq.hpp
+++ b/lager/extra/derive/eq.hpp
@@ -17,16 +17,30 @@
 
 #define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, elem__) &&a.elem__ == b.elem__
 
-#define LAGER_DERIVE_IMPL_EQ(r__, tpl__, ns__, name__, members__)              \
+#define LAGER_DERIVE_IMPL_EQ(r__, ns__, name__, members__)                     \
     namespace ns__ {                                                           \
-    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
+    inline bool operator==(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
+            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
+    }                                                                          \
+    inline bool operator!=(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return !(a == b);                                                      \
+    }                                                                          \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_TEMPLATE_IMPL_EQ(r__, ns__, tpl__, name__, members__)     \
+    namespace ns__ {                                                           \
+    template <BOOST_PP_REMOVE_PARENS(tpl__)>                                   \
     inline bool operator==(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
                            BOOST_PP_REMOVE_PARENS(name__) const& b)            \
     {                                                                          \
         return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
             r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
     }                                                                          \
-    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
+    template <BOOST_PP_REMOVE_PARENS(tpl__)>                                   \
     inline bool operator!=(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
                            BOOST_PP_REMOVE_PARENS(name__) const& b)            \
     {                                                                          \
@@ -35,7 +49,7 @@
     }                                                                          \
     //
 
-#define LAGER_DERIVE_IMPL_NESTED_EQ(r__, name__, members__)                    \
+#define LAGER_DERIVE_NESTED_IMPL_EQ(r__, name__, members__)                    \
     friend bool operator==(name__ const& a, name__ const& b)                   \
     {                                                                          \
         return true BOOST_PP_SEQ_FOR_EACH_R(                                   \

--- a/lager/extra/derive/eq.hpp
+++ b/lager/extra/derive/eq.hpp
@@ -1,0 +1,48 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#pragma once
+
+#include <boost/preprocessor/punctuation/remove_parens.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+
+#define LAGER_DERIVE_IMPL_EQ_ITER__(r__, data__, elem__) &&a.elem__ == b.elem__
+
+#define LAGER_DERIVE_IMPL_EQ(r__, tpl__, ns__, name__, members__)              \
+    namespace ns__ {                                                           \
+    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
+    inline bool operator==(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
+                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
+    {                                                                          \
+        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
+            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
+    }                                                                          \
+    BOOST_PP_REMOVE_PARENS(tpl__)                                              \
+    inline bool operator!=(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
+                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
+    {                                                                          \
+        return !(a == b);                                                      \
+    }                                                                          \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_IMPL_NESTED_EQ(r__, name__, members__)                    \
+    friend bool operator==(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return true BOOST_PP_SEQ_FOR_EACH_R(                                   \
+            r__, LAGER_DERIVE_IMPL_EQ_ITER__, _, members__);                   \
+    }                                                                          \
+    friend bool operator!=(name__ const& a, name__ const& b)                   \
+    {                                                                          \
+        return !(a == b);                                                      \
+    }                                                                          \
+    //

--- a/lager/extra/derive/hana.hpp
+++ b/lager/extra/derive/hana.hpp
@@ -1,0 +1,122 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#pragma once
+
+#include <boost/preprocessor/punctuation/comma_if.hpp>
+#include <boost/preprocessor/punctuation/remove_parens.hpp>
+#include <boost/preprocessor/seq/for_each_i.hpp>
+#include <boost/preprocessor/stringize.hpp>
+
+#include <boost/hana/accessors.hpp>
+#include <boost/hana/pair.hpp>
+#include <boost/hana/string.hpp>
+#include <boost/hana/tuple.hpp>
+
+// Copied from boost/hana/detail/struct_macros.hpp to avoid including that huge
+// fail or defining these using lambdas...
+namespace lager::struct_detail {
+
+template <typename Memptr, Memptr ptr>
+struct member_ptr
+{
+    template <typename T>
+    constexpr decltype(auto) operator()(T&& t) const
+    {
+        return static_cast<T&&>(t).*ptr;
+    }
+};
+
+constexpr std::size_t strlen(char const* s)
+{
+    std::size_t n = 0;
+    while (*s++ != '\0')
+        ++n;
+    return n;
+}
+
+template <std::size_t n, typename Names, std::size_t... i>
+constexpr auto prepare_member_name_impl(std::index_sequence<i...>)
+{
+    return boost::hana::string_c<boost::hana::at_c<n>(Names::get())[i]...>;
+}
+
+template <std::size_t n, typename Names>
+constexpr auto prepare_member_name()
+{
+    constexpr std::size_t len = strlen(boost::hana::at_c<n>(Names::get()));
+    return prepare_member_name_impl<n, Names>(std::make_index_sequence<len>{});
+}
+
+} // namespace lager::struct_detail
+
+#define LAGER_DERIVE_IMPL_HANA_ACCESSOR_NAMES_ITER__(r__, data__, i__, elem__) \
+    BOOST_PP_COMMA_IF(i__)                                                     \
+    BOOST_PP_STRINGIZE(elem__)
+
+#define LAGER_DERIVE_IMPL_HANA_ACCESSOR_PAIRS_ITER__(r__, data__, i__, elem__) \
+    BOOST_PP_COMMA_IF(i__)                                                     \
+    ::boost::hana::make_pair(                                                  \
+        ::lager::struct_detail::prepare_member_name<i__, member_names>(),      \
+        ::lager::struct_detail::member_ptr<decltype(&type_t::elem__),          \
+                                           &type_t::elem__>{})
+
+#define LAGER_DERIVE_IMPL_HANA_ACCESSORS__(r__, t__, members__)                \
+    using type_t = BOOST_PP_REMOVE_PARENS(t__);                                \
+    static constexpr auto apply()                                              \
+    {                                                                          \
+        struct member_names                                                    \
+        {                                                                      \
+            static constexpr auto get()                                        \
+            {                                                                  \
+                return ::boost::hana::make_tuple(BOOST_PP_SEQ_FOR_EACH_I_R(    \
+                    r__,                                                       \
+                    LAGER_DERIVE_IMPL_HANA_ACCESSOR_NAMES_ITER__,              \
+                    _,                                                         \
+                    members__));                                               \
+            }                                                                  \
+        };                                                                     \
+        return ::boost::hana::make_tuple(BOOST_PP_SEQ_FOR_EACH_I_R(            \
+            r__, LAGER_DERIVE_IMPL_HANA_ACCESSOR_PAIRS_ITER__, _, members__)); \
+    }
+
+#define LAGER_DERIVE_IMPL_HANA(r__, ns__, name__, members__)                   \
+    namespace boost {                                                          \
+    namespace hana {                                                           \
+    template <>                                                                \
+    struct accessors_impl<ns__::name__>                                        \
+    {                                                                          \
+        LAGER_DERIVE_IMPL_HANA_ACCESSORS__(r__, ns__::name__, members__)       \
+    };                                                                         \
+    }                                                                          \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_TEMPLATE_IMPL_HANA(r__, ns__, tpl__, name__, members__)   \
+    namespace boost {                                                          \
+    namespace hana {                                                           \
+    template <BOOST_PP_REMOVE_PARENS(tpl__)>                                   \
+    struct accessors_impl<ns__::BOOST_PP_REMOVE_PARENS(name__)>                \
+    {                                                                          \
+        LAGER_DERIVE_IMPL_HANA_ACCESSORS__(                                    \
+            r__, (ns__::BOOST_PP_REMOVE_PARENS(name__)), members__)            \
+    };                                                                         \
+    }                                                                          \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_NESTED_IMPL_HANA(r__, name__, members__)                  \
+    struct hana_accessors_impl                                                 \
+    {                                                                          \
+        LAGER_DERIVE_IMPL_HANA_ACCESSORS__(r__, name__, members__)             \
+    };                                                                         \
+    //

--- a/lager/extra/derive/hash.hpp
+++ b/lager/extra/derive/hash.hpp
@@ -12,23 +12,46 @@
 
 #pragma once
 
+#include <boost/preprocessor/punctuation/remove_parens.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+
+#include <boost/functional/hash.hpp>
+
 #include <functional>
 
-#define LAGER_DERIVE_IMPL_CEREAL_ITER__(r__, data__, i__, elem__)              \
+#define LAGER_DERIVE_IMPL_HASH_ITER__(r__, data__, elem__)                     \
     ::boost::hash_combine(seed, x.elem__);
 
 #define LAGER_DERIVE_IMPL_HASH(r__, ns__, name__, members__)                   \
     namespace std {                                                            \
     template <>                                                                \
-    struct hash<name__>                                                        \
+    struct hash<ns__::name__>                                                  \
     {                                                                          \
-        std::size_t operator()(const name__& x)                                \
+        std::size_t operator()(const ns__::name__& x)                          \
         {                                                                      \
             auto seed = std::size_t{};                                         \
-            BOOST_PP_SEQ_FOR_EACH_I_R(                                         \
-                r__, LAGER_DERIVE_IMPL_HASH_ITER__, _, members__);             \
+            BOOST_PP_SEQ_FOR_EACH_R(                                           \
+                r__, LAGER_DERIVE_IMPL_HASH_ITER__, _, members__)              \
+            return seed;                                                       \
         }                                                                      \
     };                                                                         \
+    }                                                                          \
+    //
+
+#define LAGER_DERIVE_TEMPLATE_IMPL_HASH(r__, ns__, tpl__, name__, members__)   \
+    namespace std {                                                            \
+    template <BOOST_PP_REMOVE_PARENS(tpl__)>                                   \
+    struct hash<ns__::BOOST_PP_REMOVE_PARENS(name__)>                          \
+    {                                                                          \
+        std::size_t operator()(const ns__::BOOST_PP_REMOVE_PARENS(name__) & x) \
+        {                                                                      \
+            auto seed = std::size_t{};                                         \
+            BOOST_PP_SEQ_FOR_EACH_R(                                           \
+                r__, LAGER_DERIVE_IMPL_HASH_ITER__, _, members__)              \
+            return seed;                                                       \
+        }                                                                      \
+    };                                                                         \
+    }                                                                          \
     //
 
 #define LAGER_DERIVE_NESTED_IMPL_HASH(r__, name__, members__)                  \

--- a/lager/extra/derive/hash.hpp
+++ b/lager/extra/derive/hash.hpp
@@ -1,0 +1,35 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#pragma once
+
+#include <functional>
+
+#define LAGER_DERIVE_IMPL_CEREAL_ITER__(r__, data__, i__, elem__)              \
+    ::boost::hash_combine(seed, x.elem__);
+
+#define LAGER_DERIVE_IMPL_HASH(r__, ns__, name__, members__)                   \
+    namespace std {                                                            \
+    template <>                                                                \
+    struct hash<name__>                                                        \
+    {                                                                          \
+        std::size_t operator()(const name__& x)                                \
+        {                                                                      \
+            auto seed = std::size_t{};                                         \
+            BOOST_PP_SEQ_FOR_EACH_I_R(                                         \
+                r__, LAGER_DERIVE_IMPL_HASH_ITER__, _, members__);             \
+        }                                                                      \
+    };                                                                         \
+    //
+
+#define LAGER_DERIVE_NESTED_IMPL_HASH(r__, name__, members__)                  \
+    static_assert(false, "can't implement HASH for LAGER_DERIVE_NESTED, sorry!")

--- a/lager/extra/struct.hpp
+++ b/lager/extra/struct.hpp
@@ -12,216 +12,26 @@
 
 #pragma once
 
-#include <boost/preprocessor/arithmetic/dec.hpp>
-#include <boost/preprocessor/control/expr_if.hpp>
-#include <boost/preprocessor/control/if.hpp>
-#include <boost/preprocessor/punctuation/comma_if.hpp>
-#include <boost/preprocessor/punctuation/remove_parens.hpp>
-#include <boost/preprocessor/seq/for_each_i.hpp>
-#include <boost/preprocessor/stringize.hpp>
-#include <boost/preprocessor/tuple/to_seq.hpp>
-#include <boost/preprocessor/variadic/size.hpp>
-
-#include <boost/hana/adapt_struct.hpp>
-
-/*
- *
- * LAGER_STRUCT
- * ============
- *
- */
-
-#define LAGER_STRUCT_EQ_ITER__(r__, data__, i__, elem__)                       \
-    BOOST_PP_EXPR_IF(i__, &&)                                                  \
-    a.elem__ == b.elem__
-
-#define LAGER_STRUCT_NON_EMPTY_(ns__, name__, ...)                             \
-    BOOST_HANA_ADAPT_STRUCT(ns__::name__, __VA_ARGS__);                        \
-    namespace ns__ {                                                           \
-    inline bool operator==(name__ const& a, name__ const& b)                   \
-    {                                                                          \
-        return BOOST_PP_SEQ_FOR_EACH_I(                                        \
-            LAGER_STRUCT_EQ_ITER__, _, BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)));  \
-    }                                                                          \
-    inline bool operator!=(name__ const& a, name__ const& b)                   \
-    {                                                                          \
-        return !(a == b);                                                      \
-    }                                                                          \
-    }                                                                          \
-    static_assert(true, "must use semicolon")
-
-#define LAGER_STRUCT_EMPTY_(ns__, name__)                                      \
-    BOOST_HANA_ADAPT_STRUCT(ns__::name__);                                     \
-    namespace ns__ {                                                           \
-    inline bool operator==(name__ const& a, name__ const& b) { return true; }  \
-    inline bool operator!=(name__ const& a, name__ const& b) { return false; } \
-    }                                                                          \
-    static_assert(true, "must use semicolon")
+#include <lager/extra/derive.hpp>
+#include <lager/extra/derive/eq.hpp>
+#include <lager/extra/derive/hana.hpp>
 
 /*!
  * This macro declares the struct as a Boost.Hana sequence, so it can be
  * introspected via metaprogramming.  This macro has similar syntax to
  * BOOST_HANA_ADAPT_STRUCT.
  */
-#define LAGER_STRUCT(ns__, ...)                                                \
-    BOOST_PP_IF(BOOST_PP_DEC(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__)),             \
-                LAGER_STRUCT_NON_EMPTY_,                                       \
-                LAGER_STRUCT_EMPTY_)                                           \
-    (ns__, __VA_ARGS__)
-
-/*
- *
- * LAGER_STRUCT_TEMPLATE
- * =====================
- *
- */
-
-#define LAGER_HANA_DEFINE_ACCESSOR_NAMES_ITER__(r__, data__, i__, elem__)      \
-    BOOST_PP_COMMA_IF(i__)                                                     \
-    BOOST_HANA_PP_STRINGIZE(elem__)
-
-#define LAGER_HANA_DEFINE_ACCESSOR_PAIRS_ITER__(r__, data__, i__, elem__)      \
-    BOOST_PP_COMMA_IF(i__)                                                     \
-    ::boost::hana::make_pair(                                                  \
-        ::boost::hana::struct_detail::prepare_member_name<i__,                 \
-                                                          member_names>(),     \
-        ::boost::hana::struct_detail::member_ptr<decltype(&type_t::elem__),    \
-                                                 &type_t::elem__>{})
-
-#define LAGER_HANA_DEFINE_ACCESORS_IMPL_NON_EMPTY_(t__, ...)                   \
-    using type_t = BOOST_PP_REMOVE_PARENS(t__);                                \
-    static constexpr auto apply()                                              \
-    {                                                                          \
-        struct member_names                                                    \
-        {                                                                      \
-            static constexpr auto get()                                        \
-            {                                                                  \
-                return ::boost::hana::make_tuple(BOOST_PP_SEQ_FOR_EACH_I(      \
-                    LAGER_HANA_DEFINE_ACCESSOR_NAMES_ITER__,                   \
-                    _,                                                         \
-                    BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__))));                    \
-            }                                                                  \
-        };                                                                     \
-        return ::boost::hana::make_tuple(                                      \
-            BOOST_PP_SEQ_FOR_EACH_I(LAGER_HANA_DEFINE_ACCESSOR_PAIRS_ITER__,   \
-                                    _,                                         \
-                                    BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__))));    \
-    }
-
-#define LAGER_HANA_DEFINE_ACCESORS_IMPL_EMPTY_(t__, ...)                       \
-    using type_t = BOOST_PP_REMOVE_PARENS(t__);                                \
-    static constexpr auto apply() { return boost::hana::make_tuple(); }
-
-#define LAGER_HANA_DEFINE_ACCESORS_IMPL_(...)                                  \
-    BOOST_PP_IF(BOOST_PP_DEC(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__)),             \
-                LAGER_HANA_DEFINE_ACCESORS_IMPL_NON_EMPTY_,                    \
-                LAGER_HANA_DEFINE_ACCESORS_IMPL_EMPTY_)                        \
-    (__VA_ARGS__)
-
-#define LAGER_HANA_ADAPT_STRUCT_TPL(ts__, t__, ...)                            \
-    namespace boost {                                                          \
-    namespace hana {                                                           \
-    template <BOOST_PP_REMOVE_PARENS(ts__)>                                    \
-    struct accessors_impl<BOOST_PP_REMOVE_PARENS(t__)>                         \
-    {                                                                          \
-        LAGER_HANA_DEFINE_ACCESORS_IMPL_(t__, __VA_ARGS__)                     \
-    };                                                                         \
-    }                                                                          \
-    }                                                                          \
-    static_assert(true, "force semicolon");
-
-#define LAGER_STRUCT_TEMPLATE_NON_EMPTY_(ns__, ts__, name__, ...)              \
-    LAGER_HANA_ADAPT_STRUCT_TPL(                                               \
-        ts__, (ns__::BOOST_PP_REMOVE_PARENS(name__)), __VA_ARGS__);            \
-    namespace ns__ {                                                           \
-    template <BOOST_PP_REMOVE_PARENS(ts__)>                                    \
-    inline bool operator==(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
-                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
-    {                                                                          \
-        return BOOST_PP_SEQ_FOR_EACH_I(                                        \
-            LAGER_STRUCT_EQ_ITER__, _, BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)));  \
-    }                                                                          \
-    template <BOOST_PP_REMOVE_PARENS(ts__)>                                    \
-    inline bool operator!=(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
-                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
-    {                                                                          \
-        return !(a == b);                                                      \
-    }                                                                          \
-    }                                                                          \
-    static_assert(true, "must use semicolon")
-
-#define LAGER_STRUCT_TEMPLATE_EMPTY_(ns__, ts__, name__)                       \
-    LAGER_HANA_ADAPT_STRUCT_TPL(ts__, (ns__::BOOST_PP_REMOVE_PARENS(name__))); \
-    namespace ns__ {                                                           \
-    template <BOOST_PP_REMOVE_PARENS(ts__)>                                    \
-    inline bool operator==(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
-                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
-    {                                                                          \
-        return true;                                                           \
-    }                                                                          \
-    template <BOOST_PP_REMOVE_PARENS(ts__)>                                    \
-    inline bool operator!=(BOOST_PP_REMOVE_PARENS(name__) const& a,            \
-                           BOOST_PP_REMOVE_PARENS(name__) const& b)            \
-    {                                                                          \
-        return false;                                                          \
-    }                                                                          \
-    }                                                                          \
-    static_assert(true, "must use semicolon")
+#define LAGER_STRUCT(...) LAGER_DERIVE((EQ, HANA), __VA_ARGS__)
 
 /*!
- * Like LAGER_STRUCT but for templates
+ * Like LAGER_STRUCT but for templates.
  */
-#define LAGER_STRUCT_TEMPLATE(ns__, ts__, ...)                                 \
-    BOOST_PP_IF(BOOST_PP_DEC(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__)),             \
-                LAGER_STRUCT_TEMPLATE_NON_EMPTY_,                              \
-                LAGER_STRUCT_TEMPLATE_EMPTY_)                                  \
-    (ns__, ts__, __VA_ARGS__)
-
-/*
- *
- * LAGER_STRUCT_INLINE
- * ===================
- *
- */
-
-#define LAGER_HANA_ADAPT_STRUCT_NESTED(...)                                    \
-    struct hana_accessors_impl                                                 \
-    {                                                                          \
-        LAGER_HANA_DEFINE_ACCESORS_IMPL_(__VA_ARGS__)                          \
-    } // force semicolon
-
-#define LAGER_STRUCT_NESTED_NON_EMPTY_(name__, ...)                            \
-    LAGER_HANA_ADAPT_STRUCT_NESTED(name__, __VA_ARGS__);                       \
-    friend inline bool operator==(name__ const& a, name__ const& b)            \
-    {                                                                          \
-        return BOOST_PP_SEQ_FOR_EACH_I(                                        \
-            LAGER_STRUCT_EQ_ITER__, _, BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)));  \
-    }                                                                          \
-    friend inline bool operator!=(name__ const& a, name__ const& b)            \
-    {                                                                          \
-        return !(a == b);                                                      \
-    }                                                                          \
-    static_assert(true, "must use semicolon")
-
-#define LAGER_STRUCT_NESTED_EMPTY_(name__)                                     \
-    LAGER_HANA_ADAPT_STRUCT_NESTED(name__);                                    \
-    friend inline bool operator==(name__ const& a, name__ const& b)            \
-    {                                                                          \
-        return true;                                                           \
-    }                                                                          \
-    friend inline bool operator!=(name__ const& a, name__ const& b)            \
-    {                                                                          \
-        return false;                                                          \
-    }                                                                          \
-    static_assert(true, "must use semicolon")
+#define LAGER_STRUCT_TEMPLATE(...)                                             \
+    LAGER_DERIVE_TEMPLATE((EQ, HANA), __VA_ARGS__)
 
 /*!
  * Like LAGER_STRUCT but for it is used nested in the struct itself.  It
  * seamlesly supports combinations of templates and nested types that are not
  * supported by the above macros.
  */
-#define LAGER_STRUCT_NESTED(...)                                               \
-    BOOST_PP_IF(BOOST_PP_DEC(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__)),             \
-                LAGER_STRUCT_NESTED_NON_EMPTY_,                                \
-                LAGER_STRUCT_NESTED_EMPTY_)                                    \
-    (__VA_ARGS__)
+#define LAGER_STRUCT_NESTED(...) LAGER_DERIVE_NESTED((EQ, HANA), __VA_ARGS__)

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -10,9 +10,12 @@
 // or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
 //
 
+#include "test/cereal/cerealize.hpp"
+
 #include <catch.hpp>
 
 #include <lager/extra/derive.hpp>
+#include <lager/extra/derive/cereal.hpp>
 #include <lager/extra/derive/eq.hpp>
 #include <lager/extra/derive/hana.hpp>
 
@@ -27,7 +30,7 @@ struct derived
 };
 } // namespace ns
 
-LAGER_DERIVE((EQ, HANA), ns, derived, a, b);
+LAGER_DERIVE((EQ, HANA, CEREAL), ns, derived, a, b);
 
 TEST_CASE("basic")
 {
@@ -44,6 +47,9 @@ TEST_CASE("basic")
     CHECK(members ==
           immer::array<std::string>{{std::string{"a"}, std::string{"b"}}});
     CHECK(acc == 54);
+
+    auto z = cerealize(x);
+    CHECK(z == x);
 }
 
 namespace ns {
@@ -51,13 +57,16 @@ struct empty_t
 {};
 } // namespace ns
 
-LAGER_DERIVE(EQ, ns, empty_t);
+LAGER_DERIVE((EQ, CEREAL), ns, empty_t);
 
 TEST_CASE("empty")
 {
     auto x = ns::empty_t{};
     auto y = x;
     CHECK(x == y);
+
+    auto z = cerealize(x);
+    CHECK(z == x);
 }
 
 namespace ns {
@@ -70,7 +79,7 @@ struct foo_tpl
 } // namespace ns
 
 LAGER_DERIVE_TEMPLATE(
-    (EQ, HANA), ns, (class A, class B), (foo_tpl<A, B>), a, b);
+    (EQ, HANA, CEREAL), ns, (class A, class B), (foo_tpl<A, B>), a, b);
 
 TEST_CASE("template")
 {
@@ -87,6 +96,9 @@ TEST_CASE("template")
     CHECK(members ==
           immer::array<std::string>{{std::string{"a"}, std::string{"b"}}});
     CHECK(acc == 54);
+
+    auto z = cerealize(x);
+    CHECK(z == x);
 }
 
 namespace ns {
@@ -97,7 +109,7 @@ struct foo_tpl2
     {
         A a;
         B b;
-        LAGER_DERIVE_NESTED((EQ, HANA), nested, a, b);
+        LAGER_DERIVE_NESTED((EQ, HANA, CEREAL), nested, a, b);
     };
 };
 } // namespace ns
@@ -117,4 +129,7 @@ TEST_CASE("template_nested")
     CHECK(members ==
           immer::array<std::string>{{std::string{"a"}, std::string{"b"}}});
     CHECK(acc == 54);
+
+    auto z = cerealize(x);
+    CHECK(z == x);
 }

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -44,3 +44,21 @@ TEST_CASE("empty")
     auto y = x;
     CHECK(x == y);
 }
+
+namespace ns {
+template <typename A, typename B>
+struct foo_tpl
+{
+    A a;
+    B b;
+};
+} // namespace ns
+
+LAGER_DERIVE_TEMPLATE(EQ, ns, (class A, class B), (foo_tpl<A, B>), a, b);
+
+TEST_CASE("template")
+{
+    auto x = ns::foo_tpl<float, int>{42, 12};
+    auto y = x;
+    CHECK(x == y);
+}

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -62,3 +62,23 @@ TEST_CASE("template")
     auto y = x;
     CHECK(x == y);
 }
+
+namespace ns {
+template <typename A, typename B>
+struct foo_tpl2
+{
+    struct nested
+    {
+        A a;
+        B b;
+        LAGER_DERIVE_NESTED(EQ, nested, a, b);
+    };
+};
+} // namespace ns
+
+TEST_CASE("template_nested")
+{
+    auto x = ns::foo_tpl2<float, int>::nested{42, 12};
+    auto y = x;
+    CHECK(x == y);
+}

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -22,11 +22,25 @@ struct derived
 };
 } // namespace ns
 
-LAGER_DERIVE((EQ), ns, derived, a, b);
+LAGER_DERIVE(EQ, ns, derived, a, b);
 
 TEST_CASE("basic")
 {
     auto x = ns::derived{42, 12};
+    auto y = x;
+    CHECK(x == y);
+}
+
+namespace ns {
+struct empty_t
+{};
+} // namespace ns
+
+LAGER_DERIVE((EQ), ns, empty_t);
+
+TEST_CASE("empty")
+{
+    auto x = ns::empty_t{};
     auto y = x;
     CHECK(x == y);
 }

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -13,6 +13,7 @@
 #include <catch.hpp>
 
 #include <lager/extra/derive.hpp>
+#include <lager/extra/derive/eq.hpp>
 
 namespace ns {
 struct derived

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -1,0 +1,32 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#include <catch.hpp>
+
+#include <lager/extra/derive.hpp>
+
+namespace ns {
+struct derived
+{
+    int a;
+    float b;
+};
+} // namespace ns
+
+LAGER_DERIVE((EQ), ns, derived, a, b);
+
+TEST_CASE("basic")
+{
+    auto x = ns::derived{42, 12};
+    auto y = x;
+    CHECK(x == y);
+}

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -18,6 +18,7 @@
 #include <lager/extra/derive/cereal.hpp>
 #include <lager/extra/derive/eq.hpp>
 #include <lager/extra/derive/hana.hpp>
+#include <lager/extra/derive/hash.hpp>
 
 #include <boost/hana/assert.hpp>
 #include <boost/hana/equal.hpp>
@@ -26,6 +27,7 @@
 #include <boost/hana/size.hpp>
 
 #include <immer/array.hpp>
+#include <immer/set.hpp>
 
 namespace {
 
@@ -60,6 +62,14 @@ void check_cereal()
     CHECK(y == x);
 }
 
+template <typename T>
+void check_hash()
+{
+    auto m = immer::set<T>{}.insert(T{42, 12});
+    CHECK(m.count(T{42, 12}) == 1);
+    CHECK(m.count(T{42, 13}) == 0);
+}
+
 } // namespace
 
 namespace ns {
@@ -69,13 +79,14 @@ struct derived
     float b;
 };
 } // namespace ns
-LAGER_DERIVE((EQ, HANA, CEREAL), ns, derived, a, b);
+LAGER_DERIVE((EQ, HANA, CEREAL, HASH), ns, derived, a, b);
 
 TEST_CASE("basic")
 {
     check_eq<ns::derived>();
     check_hana<ns::derived>();
     check_cereal<ns::derived>();
+    check_hash<ns::derived>();
 }
 
 namespace ns {
@@ -101,13 +112,14 @@ struct foo_tpl
 };
 } // namespace ns
 LAGER_DERIVE_TEMPLATE(
-    (EQ, HANA, CEREAL), ns, (class A, class B), (foo_tpl<A, B>), a, b);
+    (EQ, HANA, CEREAL, HASH), ns, (class A, class B), (foo_tpl<A, B>), a, b);
 
 TEST_CASE("template")
 {
     check_eq<ns::foo_tpl<int, float>>();
     check_hana<ns::foo_tpl<int, float>>();
     check_cereal<ns::foo_tpl<int, float>>();
+    check_hash<ns::foo_tpl<int, float>>();
 }
 
 namespace ns {

--- a/test/extra/derive.cpp
+++ b/test/extra/derive.cpp
@@ -14,6 +14,10 @@
 
 #include <lager/extra/derive.hpp>
 #include <lager/extra/derive/eq.hpp>
+#include <lager/extra/derive/hana.hpp>
+
+#include <boost/hana/for_each.hpp>
+#include <immer/array.hpp>
 
 namespace ns {
 struct derived
@@ -23,13 +27,23 @@ struct derived
 };
 } // namespace ns
 
-LAGER_DERIVE(EQ, ns, derived, a, b);
+LAGER_DERIVE((EQ, HANA), ns, derived, a, b);
 
 TEST_CASE("basic")
 {
     auto x = ns::derived{42, 12};
     auto y = x;
     CHECK(x == y);
+
+    auto members = immer::array<std::string>{};
+    auto acc     = 0;
+    boost::hana::for_each(x, [&](auto&& x) {
+        members = std::move(members).push_back(boost::hana::first(x).c_str());
+        acc += boost::hana::second(x);
+    });
+    CHECK(members ==
+          immer::array<std::string>{{std::string{"a"}, std::string{"b"}}});
+    CHECK(acc == 54);
 }
 
 namespace ns {
@@ -37,7 +51,7 @@ struct empty_t
 {};
 } // namespace ns
 
-LAGER_DERIVE((EQ), ns, empty_t);
+LAGER_DERIVE(EQ, ns, empty_t);
 
 TEST_CASE("empty")
 {
@@ -55,13 +69,24 @@ struct foo_tpl
 };
 } // namespace ns
 
-LAGER_DERIVE_TEMPLATE(EQ, ns, (class A, class B), (foo_tpl<A, B>), a, b);
+LAGER_DERIVE_TEMPLATE(
+    (EQ, HANA), ns, (class A, class B), (foo_tpl<A, B>), a, b);
 
 TEST_CASE("template")
 {
     auto x = ns::foo_tpl<float, int>{42, 12};
     auto y = x;
     CHECK(x == y);
+
+    auto members = immer::array<std::string>{};
+    auto acc     = 0;
+    boost::hana::for_each(x, [&](auto&& x) {
+        members = std::move(members).push_back(boost::hana::first(x).c_str());
+        acc += boost::hana::second(x);
+    });
+    CHECK(members ==
+          immer::array<std::string>{{std::string{"a"}, std::string{"b"}}});
+    CHECK(acc == 54);
 }
 
 namespace ns {
@@ -72,7 +97,7 @@ struct foo_tpl2
     {
         A a;
         B b;
-        LAGER_DERIVE_NESTED(EQ, nested, a, b);
+        LAGER_DERIVE_NESTED((EQ, HANA), nested, a, b);
     };
 };
 } // namespace ns
@@ -82,4 +107,14 @@ TEST_CASE("template_nested")
     auto x = ns::foo_tpl2<float, int>::nested{42, 12};
     auto y = x;
     CHECK(x == y);
+
+    auto members = immer::array<std::string>{};
+    auto acc     = 0;
+    boost::hana::for_each(x, [&](auto&& x) {
+        members = std::move(members).push_back(boost::hana::first(x).c_str());
+        acc += boost::hana::second(x);
+    });
+    CHECK(members ==
+          immer::array<std::string>{{std::string{"a"}, std::string{"b"}}});
+    CHECK(acc == 54);
 }


### PR DESCRIPTION
Finally! This is something I've been meaning to do for a while and that is useful in quite a few of the production systems currently using Lager. One way to think about it is as a dirty Haskell `deriving()` clause.

This branch adds a series of `LAGER_DERIVE`, `LAGER_DERIVE_TEMPLATE` and `LAGER_DERIVE_NESTED` macros that provide some generic infrastructure for generating code for structs using the Boost.Processor library. This generalizes the mechanisms previously included in `LAGER_STRUCT` friends. The generators are extendable, for now the following are provided:
- **EQ**: generates `operator==` and `operator!=`
- **HANA**: turns the struct into a Boost.Hana sequence... a glorified `BOOST_HANA_ADAPT_STRUCT`.
- **CEREAL**: generates serialization using Cereal, without going through Boost.Hana (this may be a bit more performant at compile time.)
- **HASH**: generates `std::hash` implementation.

For now, check `test/extra/derived.cc` for the syntax and example usage.