### PR TITLE
Fix unpacking the of nodes in lens reader nodes

### DIFF
--- a/lager/detail/lens_nodes.hpp
+++ b/lager/detail/lens_nodes.hpp
@@ -38,14 +38,14 @@ class lens_reader_node<Lens, zug::meta::pack<Parents...>, Base>
     : public inner_node<
           std::decay_t<decltype(view(
               std::declval<Lens>(),
-              zug::tuplify(std::declval<zug::meta::value_t<Parents>...>())))>,
+              zug::tuplify(std::declval<zug::meta::value_t<Parents>>()...)))>,
           zug::meta::pack<Parents...>,
           Base>
 {
     using base_t = inner_node<
         std::decay_t<decltype(view(
             std::declval<Lens>(),
-            zug::tuplify(std::declval<zug::meta::value_t<Parents>...>())))>,
+            zug::tuplify(std::declval<zug::meta::value_t<Parents>>()...)))>,
         zug::meta::pack<Parents...>,
         Base>;
 

--- a/test/cursor.cpp
+++ b/test/cursor.cpp
@@ -18,6 +18,9 @@
 #include <lager/state.hpp>
 #include <lager/writer.hpp>
 
+#include <lager/lenses.hpp>
+#include <lager/lenses/tuple.hpp>
+
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/fusion/include/comparison.hpp>
 
@@ -199,4 +202,18 @@ TEST_CASE("automatic_tag edge case")
     cur.set(42); // this would cause a crash before commit aefd37b
 
     st.set(vec_t{1, 2, 3, 4}); // this will collect garbage
+}
+
+TEST_CASE("lenses over with expression")
+{
+    state<person, automatic_tag> person_data;
+
+    person_data.set(person{{}, "old name", {}});
+
+    cursor<std::string> name = with(person_data[&person::name], person_data[&person::birthday]).zoom(lenses::first);
+
+    name.set("new name");
+
+    CHECK(person_data->name == "new name");
+    CHECK(name.get() == "new name");
 }

--- a/test/lenses.cpp
+++ b/test/lenses.cpp
@@ -16,7 +16,6 @@
 #include <zug/compose.hpp>
 #include <zug/util.hpp>
 
-#include <lager/state.hpp>
 #include <lager/lenses.hpp>
 #include <lager/lenses/at.hpp>
 #include <lager/lenses/at_or.hpp>
@@ -610,18 +609,4 @@ TEST_CASE("lenses::element array", "[lenses][element][array]")
     CHECK(view(second, foo) == 2);
 
     CHECK(over(element<1>, foo, increment) == (std::array{1, 3, 3}));
-}
-
-TEST_CASE("lenses over with expression")
-{
-    state<person, automatic_tag> person_data;
-
-    person_data.set(person{{}, "old name", {}});
-
-    cursor<std::string> name = with(person_data[&person::name], person_data[&person::birthday]).zoom(lenses::first);
-
-    name.set("new name");
-
-    CHECK(person_data->name == "new name");
-    CHECK(name.get() == "new name");
 }

--- a/test/lenses.cpp
+++ b/test/lenses.cpp
@@ -618,11 +618,7 @@ TEST_CASE("lenses over with expression")
 
     person_data.set(person{{}, "old name", {}});
 
-    auto name_lens = lenses::getset(
-        [] (std::tuple<std::string, yearday> x) { return std::get<0>(x); },
-        [] (std::tuple<std::string, yearday> x, std::string new_name) { return std::make_tuple(new_name, std::get<1>(x)); });
-
-    cursor<std::string> name = with(person_data[&person::name], person_data[&person::birthday]).zoom(name_lens);
+    cursor<std::string> name = with(person_data[&person::name], person_data[&person::birthday]).zoom(lenses::first);
 
     name.set("new name");
 


### PR DESCRIPTION
It breaks applying a lens expression over the result of .with() expression.