### PR TITLE
Delete ambiguous assigment operators in `state`

### DIFF
--- a/lager/state.hpp
+++ b/lager/state.hpp
@@ -94,6 +94,13 @@ public:
 
     state(state&&) = default;
     state& operator=(state&&) = default;
+
+    /*!
+     * Deletes implicit creation and replacement of the store
+     * when it is assigned with the base type
+     */
+    state& operator=(const T&) = delete;
+    state& operator=(T&&) = delete;
 };
 
 template <typename T>


### PR DESCRIPTION
It is possible to assign a state with the new value, which implicitly
creates a new state and replaces the current one. It basically detaches
all the cursors and listeners.

Alternatively, the problem can be solved by making the constructor
explicit, but it may create some inconviniences when using the state.

fixes #135