### PR TITLE
Forward reducer in with_reducer enhancer

### DIFF
--- a/lager/store.hpp
+++ b/lager/store.hpp
@@ -273,7 +273,7 @@ auto with_deps(Args&&... args)
 template <typename Reducer>
 auto with_reducer(Reducer&& reducer)
 {
-    return [reducer](auto next) {
+    return [reducer = LAGER_FWD(reducer)](auto next) {
         return [reducer, next](auto action,
                                auto&& model,
                                auto&& old_reducer,

--- a/test/core.cpp
+++ b/test/core.cpp
@@ -56,6 +56,19 @@ TEST_CASE("basic")
     CHECK(store.get().value == 1);
 }
 
+TEST_CASE("with reducer enhancer")
+{
+    auto reducer = [](counter::model m, counter::action) { return m; };
+    auto store =
+        lager::make_store<counter::action>(counter::model{},
+                                           lager::with_manual_event_loop{},
+                                           lager::with_reducer(reducer));
+
+    CHECK(store.get().value == 0);
+    store.dispatch(counter::increment_action{});
+    CHECK(store.get().value == 0);
+}
+
 TEST_CASE("effect as a result")
 {
     auto viewed = std::optional<int>{std::nullopt};


### PR DESCRIPTION
This was causing a weird binding error in clang on the `reducer` capture of the inner lambda when the enhancer is passed an lvalue.