### PR TITLE
Reimplement the lager::http_debug_server using Boost.Beast

### DIFF
--- a/example/counter/ncurses/terminal.hpp
+++ b/example/counter/ncurses/terminal.hpp
@@ -21,6 +21,7 @@
 
 extern "C"
 {
+#define NCURSES_NOMACROS
 #include <ncurses.h>
 }
 

--- a/lager/debug/http_server.hpp
+++ b/lager/debug/http_server.hpp
@@ -20,26 +20,234 @@
 #include <cereal/types/optional.hpp>
 #include <lager/extra/cereal/variant_with_name.hpp>
 
-#include <httpserver.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
 
 #include <atomic>
+#include <fstream>
 #include <functional>
 #include <memory>
+#include <regex>
 #include <sstream>
+#include <thread>
 #include <vector>
 
 namespace lager {
 
-namespace detail {
+namespace beast = boost::beast;
+namespace asio  = boost::asio;
 
-bool ends_with(const std::string& str, const std::string& ending)
+namespace detail::http {
+class router
 {
-    return str.length() >= ending.length() &&
-           str.compare(
-               str.length() - ending.length(), ending.length(), ending) == 0;
-}
+public:
+    using req_t = beast::http::request<beast::http::string_body>;
+    using res_t = beast::http::response<beast::http::string_body>;
 
-} // namespace detail
+private:
+    struct resource_t
+    {
+        beast::http::verb method;
+        std::regex target;
+        std::function<res_t(req_t&&)> handler;
+    };
+
+    std::vector<resource_t> resources_;
+
+public:
+    void register_resource(beast::http::verb method,
+                           const std::string& target,
+                           std::function<res_t(req_t&&)> handler)
+    {
+        resources_.push_back({method, std::regex{target}, std::move(handler)});
+    }
+
+    res_t handle_request(req_t&& req)
+    {
+        auto it = std::find_if(resources_.begin(),
+                               resources_.end(),
+                               [&](const resource_t& resource) {
+                                   return resource.method == req.method() &&
+                                          std::regex_match(req.target().begin(),
+                                                           req.target().end(),
+                                                           resource.target);
+                               });
+
+        if (it != resources_.end()) {
+            try {
+                return it->handler(std::move(req));
+            } catch (const std::exception& err) {
+                return create_response_(500, "text/html", err.what());
+            }
+        }
+
+        return create_response_(404, "text/html", "Not found");
+    }
+
+private:
+    static res_t create_response_(unsigned status_code,
+                                  beast::string_view content_type,
+                                  std::string body)
+    {
+        res_t res;
+        res.result(status_code);
+        res.set(beast::http::field::content_type, content_type);
+        res.body() = std::move(body);
+        res.prepare_payload();
+        return res;
+    }
+};
+
+class session : public std::enable_shared_from_this<session>
+{
+    router* router_;
+    asio::ip::tcp::socket socket_;
+    beast::flat_buffer buffer_;
+    beast::http::request<beast::http::string_body> req_;
+    beast::http::response<beast::http::string_body> res_;
+
+public:
+    session(router* router, asio::ip::tcp::socket&& socket)
+        : router_{router}
+        , socket_(std::move(socket))
+    {
+    }
+
+    void run() { do_read_(); }
+
+private:
+    void do_read_()
+    {
+        // Make the request empty before reading
+        req_ = {};
+
+        beast::http::async_read(socket_,
+                                buffer_,
+                                req_,
+                                std::bind(&session::on_read_,
+                                          shared_from_this(),
+                                          std::placeholders::_1,
+                                          std::placeholders::_2));
+    }
+
+    void on_read_(beast::error_code ec, std::size_t)
+    {
+        if (ec)
+            return do_close_();
+
+        // Keep response alive during the write operation
+        res_ = router_->handle_request(std::move(req_));
+
+        beast::http::async_write(socket_,
+                                 res_,
+                                 std::bind(&session::on_write_,
+                                           shared_from_this(),
+                                           std::placeholders::_1,
+                                           std::placeholders::_2,
+                                           res_.need_eof()));
+    }
+
+    void on_write_(beast::error_code ec, std::size_t, bool close)
+    {
+        if (ec || close)
+            return do_close_();
+
+        do_read_();
+    }
+
+    void do_close_()
+    {
+        beast::error_code ec;
+        socket_.shutdown(asio::ip::tcp::socket::shutdown_send, ec);
+    }
+};
+
+class listener : public std::enable_shared_from_this<listener>
+{
+    router* router_;
+    asio::ip::tcp::acceptor acceptor_;
+
+public:
+    listener(router* router,
+             asio::io_context* ioc,
+             const asio::ip::tcp::endpoint& endpoint)
+        : router_{router}
+        , acceptor_{*ioc}
+    {
+        beast::error_code ec;
+
+        acceptor_.open(endpoint.protocol(), ec);
+        if (ec)
+            throw std::runtime_error{"acceptor failed on open, err:" +
+                                     std::string{ec.message()}};
+
+        acceptor_.set_option(asio::socket_base::reuse_address(true), ec);
+        if (ec)
+            throw std::runtime_error{"acceptor failed on set_option, err:" +
+                                     std::string{ec.message()}};
+
+        acceptor_.bind(endpoint, ec);
+        if (ec)
+            throw std::runtime_error{"acceptor failed on bind, err:" +
+                                     std::string{ec.message()}};
+
+        acceptor_.listen(asio::socket_base::max_listen_connections, ec);
+        if (ec)
+            throw std::runtime_error{"acceptor failed on listen, err:" +
+                                     std::string{ec.message()}};
+    }
+
+    void run() { do_accept_(); }
+
+private:
+    void do_accept_()
+    {
+        acceptor_.async_accept(std::bind(&listener::on_accept_,
+                                         shared_from_this(),
+                                         std::placeholders::_1,
+                                         std::placeholders::_2));
+    }
+
+    void on_accept_(boost::system::error_code ec, asio::ip::tcp::socket socket)
+    {
+        if (ec)
+            return;
+
+        std::make_shared<session>(router_, std::move(socket))->run();
+
+        do_accept_();
+    }
+};
+
+class server
+{
+    router router_;
+    asio::io_context io_context_;
+    std::shared_ptr<listener> listener_;
+    std::thread thread_;
+
+public:
+    server(uint16_t port, router router)
+        : router_{std::move(router)}
+        , listener_{std::make_shared<listener>(
+              &router_,
+              &io_context_,
+              asio::ip::tcp::endpoint{asio::ip::tcp::v4(), port})}
+    {
+        listener_->run();
+        thread_ = std::thread{[&] { io_context_.run(); }};
+    }
+
+    ~server()
+    {
+        io_context_.stop();
+
+        if (thread_.joinable())
+            thread_.join();
+    }
+};
+} // namespace detail::http
 
 class http_debug_server
 {
@@ -61,7 +269,7 @@ public:
 
         void set_context(context_t ctx) { context_ = std::move(ctx); }
         void set_reader(reader_t data) { data_ = std::move(data); }
-        std::string const& resources_path() { return resources_path_; }
+        std::string const& resources_path() const { return resources_path_; }
 
     private:
         friend http_debug_server;
@@ -100,128 +308,158 @@ public:
             return *m;
         }
 
-        struct resource_t : httpserver::http_resource
-        {
-            handle& self;
-            resource_t(handle& hdl)
-                : self{hdl}
-            {}
-        };
+        using req_t = detail::http::router::req_t;
+        using res_t = detail::http::router::res_t;
 
-        using response_t = const std::shared_ptr<httpserver::http_response>;
-        using request_t  = httpserver::http_request;
-
-        struct : resource_t
+        res_t root_resource_(req_t&&) const
         {
-            using resource_t::resource_t;
-            response_t render_GET(const request_t& req) override
+            auto m = get_model_();
+            auto s = std::ostringstream{};
             {
-                auto m = this->self.get_model_();
-                auto s = std::ostringstream{};
-                {
-                    auto a = cereal::JSONOutputArchive{s};
-                    a(cereal::make_nvp("program", this->self.program_),
-                      cereal::make_nvp("summary", m.summary()),
-                      cereal::make_nvp("cursor", m.cursor),
-                      cereal::make_nvp("paused", m.paused));
-                }
-                return std::make_shared<httpserver::string_response>(
-                    s.str(), 200, "text/json");
+                auto a = cereal::JSONOutputArchive{s};
+                a(cereal::make_nvp("program", program_),
+                  cereal::make_nvp("summary", m.summary()),
+                  cereal::make_nvp("cursor", m.cursor),
+                  cereal::make_nvp("paused", m.paused));
             }
-        } root_resource_ = {*this};
+            return create_response_(200, "application/json", s.str());
+        }
 
-        struct : resource_t
+        res_t step_resource_(req_t&& req) const
         {
-            using resource_t::resource_t;
-            response_t render_GET(const request_t& req) override
+            auto m = get_model_();
+            auto s = std::ostringstream{};
             {
-                auto m = this->self.get_model_();
-                auto s = std::ostringstream{};
-                {
-                    auto cursor = std::stoul(req.get_arg("cursor"));
-                    auto result = m.lookup(cursor);
-                    auto a      = cereal::JSONOutputArchive{s};
-                    if (result.first)
-                        a(cereal::make_nvp("action", *result.first));
-                    a(cereal::make_nvp("model", result.second));
-                }
-                return std::make_shared<httpserver::string_response>(
-                    s.str(), 200, "text/json");
+                auto target = req.target().to_string();
+                auto cursor = std::stoul(target.substr(target.rfind('/') + 1));
+                auto result = m.lookup(cursor);
+                auto a      = cereal::JSONOutputArchive{s};
+                if (result.first)
+                    a(cereal::make_nvp("action", *result.first));
+                a(cereal::make_nvp("model", result.second));
             }
-        } step_resource_ = {*this};
+            return create_response_(200, "application/json", s.str());
+        }
 
-        struct : resource_t
+        res_t goto_resource_(req_t&& req)
         {
-            using resource_t::resource_t;
-            response_t render_POST(const request_t& req) override
-            {
-                auto cursor = std::stoul(req.get_arg("cursor"));
-                this->self.context_.dispatch(
-                    typename Debugger::goto_action{cursor});
-                return std::make_shared<httpserver::string_response>("", 200);
-            }
-        } goto_resource_ = {*this};
+            auto target = req.target().to_string();
+            auto cursor = std::stoul(target.substr(target.rfind('/') + 1));
+            context_.dispatch(typename Debugger::goto_action{cursor});
+            return create_response_(200, "text/html", "");
+        }
 
-        struct : resource_t
+        res_t undo_resource_(req_t&&)
         {
-            using resource_t::resource_t;
-            response_t render_POST(const request_t& req) override
-            {
-                this->self.context_.dispatch(typename Debugger::undo_action{});
-                return std::make_shared<httpserver::string_response>("", 200);
-            }
-        } undo_resource_ = {*this};
+            context_.dispatch(typename Debugger::undo_action{});
+            return create_response_(200, "text/html", "");
+        }
 
-        struct : resource_t
+        res_t redo_resource_(req_t&&)
         {
-            using resource_t::resource_t;
-            response_t render_POST(const request_t& req) override
-            {
-                this->self.context_.dispatch(typename Debugger::redo_action{});
-                return std::make_shared<httpserver::string_response>("", 200);
-            }
-        } redo_resource_ = {*this};
+            context_.dispatch(typename Debugger::redo_action{});
+            return create_response_(200, "text/html", "");
+        }
 
-        struct : resource_t
+        res_t pause_resource_(req_t&&)
         {
-            using resource_t::resource_t;
-            response_t render_POST(const request_t& req) override
-            {
-                this->self.context_.dispatch(typename Debugger::pause_action{});
-                return std::make_shared<httpserver::string_response>("", 200);
-            }
-        } pause_resource_ = {*this};
+            context_.dispatch(typename Debugger::pause_action{});
+            return create_response_(200, "text/html", "");
+        }
 
-        struct : resource_t
+        res_t resume_resource_(req_t&&)
         {
-            using resource_t::resource_t;
-            response_t render_POST(const request_t& req) override
-            {
-                this->self.context_.dispatch(
-                    typename Debugger::resume_action{});
-                return std::make_shared<httpserver::string_response>("", 200);
-            }
-        } resume_resource_ = {*this};
+            context_.dispatch(typename Debugger::resume_action{});
+            return create_response_(200, "text/html", "");
+        }
 
-        struct : resource_t
+        res_t gui_resource_(req_t&& req) const
         {
-            using resource_t::resource_t;
-            response_t render_GET(const request_t& req) override
-            {
-                auto req_path = req.get_path();
-                auto rel_path =
-                    req_path == "/" ? "/gui/index.html" : "/gui/" + req_path;
-                auto full_path = this->self.resources_path() + rel_path;
-                auto content_type =
-                    detail::ends_with(full_path, ".html")  ? "text/html"
-                    : detail::ends_with(full_path, ".js")  ? "text/javascript"
-                    : detail::ends_with(full_path, ".css") ? "text/css"
-                                                           /* otherwise */
-                                                           : "text/plain";
-                return std::make_shared<httpserver::file_response>(
-                    full_path, 200, content_type);
-            }
-        } gui_resource_ = {*this};
+            auto req_path = req.target().to_string();
+            auto rel_path =
+                req_path == "/" ? "/gui/index.html" : "/gui/" + req_path;
+            auto full_path = resources_path() + rel_path;
+
+            std::ifstream ifs{full_path};
+            if (!ifs.is_open())
+                return create_response_(404, "text/html", "Not found");
+
+            /*
+              The whole file content is read synchronously into string, this
+              shouldn't be a performance issue because it's used only in gui
+              startup and has no blocking effect on the application because
+              http::server has its own thread.
+            */
+            using it_t = std::istreambuf_iterator<char>;
+            return create_response_(
+                200, mime_type_(full_path), std::string{it_t(ifs), it_t()});
+        }
+
+        static beast::string_view mime_type_(beast::string_view path)
+        {
+            using beast::iequals;
+            auto const ext = [&path] {
+                auto const pos = path.rfind(".");
+                if (pos == beast::string_view::npos)
+                    return beast::string_view{};
+                return path.substr(pos);
+            }();
+            if (iequals(ext, ".htm"))
+                return "text/html";
+            if (iequals(ext, ".html"))
+                return "text/html";
+            if (iequals(ext, ".php"))
+                return "text/html";
+            if (iequals(ext, ".css"))
+                return "text/css";
+            if (iequals(ext, ".txt"))
+                return "text/plain";
+            if (iequals(ext, ".js"))
+                return "application/javascript";
+            if (iequals(ext, ".json"))
+                return "application/json";
+            if (iequals(ext, ".xml"))
+                return "application/xml";
+            if (iequals(ext, ".swf"))
+                return "application/x-shockwave-flash";
+            if (iequals(ext, ".flv"))
+                return "video/x-flv";
+            if (iequals(ext, ".png"))
+                return "image/png";
+            if (iequals(ext, ".jpe"))
+                return "image/jpeg";
+            if (iequals(ext, ".jpeg"))
+                return "image/jpeg";
+            if (iequals(ext, ".jpg"))
+                return "image/jpeg";
+            if (iequals(ext, ".gif"))
+                return "image/gif";
+            if (iequals(ext, ".bmp"))
+                return "image/bmp";
+            if (iequals(ext, ".ico"))
+                return "image/vnd.microsoft.icon";
+            if (iequals(ext, ".tiff"))
+                return "image/tiff";
+            if (iequals(ext, ".tif"))
+                return "image/tiff";
+            if (iequals(ext, ".svg"))
+                return "image/svg+xml";
+            if (iequals(ext, ".svgz"))
+                return "image/svg+xml";
+            return "application/text";
+        }
+
+        static res_t create_response_(unsigned status_code,
+                                      beast::string_view content_type,
+                                      std::string body)
+        {
+            res_t res;
+            res.result(status_code);
+            res.set(beast::http::field::content_type, content_type);
+            res.body() = std::move(body);
+            res.prepare_payload();
+            return res;
+        }
     };
 
     http_debug_server(int argc,
@@ -230,38 +468,78 @@ public:
                       std::string resources_path)
         : argc_{argc}
         , argv_{argv}
+        , port_{port}
         , resources_path_{std::move(resources_path)}
-        , server_{httpserver::create_webserver(port)}
-    {}
+    {
+    }
 
     template <typename Debugger>
     handle<Debugger>& enable(Debugger)
     {
         assert(!handle_);
-        assert(!server_.is_running());
         using handle_t = handle<Debugger>;
         auto hdl_      = std::unique_ptr<handle_t>(
             new handle_t{argc_, argv_, resources_path_});
         auto& hdl = *hdl_;
-        server_.register_resource("/api/step/{cursor}", &hdl.step_resource_);
-        server_.register_resource("/api/goto/{cursor}", &hdl.goto_resource_);
-        server_.register_resource("/api/undo", &hdl.undo_resource_);
-        server_.register_resource("/api/redo", &hdl.redo_resource_);
-        server_.register_resource("/api/pause", &hdl.pause_resource_);
-        server_.register_resource("/api/resume", &hdl.resume_resource_);
-        server_.register_resource("/api/?", &hdl.root_resource_);
-        server_.register_resource("/?.*", &hdl.gui_resource_);
+
+        detail::http::router router;
+
+        namespace ph = std::placeholders;
+
+        router.register_resource(
+            beast::http::verb::get,
+            "/api/?",
+            std::bind(&handle_t::root_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::get,
+            "/api/step/[0-9]+",
+            std::bind(&handle_t::step_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::post,
+            "/api/goto/[0-9]+",
+            std::bind(&handle_t::goto_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::post,
+            "/api/undo",
+            std::bind(&handle_t::undo_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::post,
+            "/api/redo",
+            std::bind(&handle_t::redo_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::post,
+            "/api/pause",
+            std::bind(&handle_t::pause_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::post,
+            "/api/resume",
+            std::bind(&handle_t::resume_resource_, &hdl, ph::_1));
+
+        router.register_resource(
+            beast::http::verb::get,
+            "/?.*",
+            std::bind(&handle_t::gui_resource_, &hdl, ph::_1));
+
+        server_ =
+            std::make_unique<detail::http::server>(port_, std::move(router));
+
         handle_ = std::move(hdl_);
-        server_.start();
         return hdl;
     }
 
 private:
     int argc_;
     const char** argv_;
+    std::uint16_t port_;
     std::string resources_path_;
-    httpserver::webserver server_        = httpserver::create_webserver(8080);
-    std::unique_ptr<handle_base> handle_ = nullptr;
+    std::unique_ptr<detail::http::server> server_ = nullptr;
+    std::unique_ptr<handle_base> handle_          = nullptr;
 };
 
 } // namespace lager


### PR DESCRIPTION
This is a draft PR for #140

- Because lager is header only, a low footprint implementation that meets current requirements has been in mind.
- There is no dependency on [libhttpserver](https://github.com/etr/libhttpserver) anymore but cmake and nix files need modification.
- If windows support is required, manipulation of `resources_path` should be different.
- Currently, there are no unit tests for http_debug_server, we need some idea of how it should be done.