### PR TITLE
Make `lager::match` work with types that are derived from `std::variant`

### DIFF
--- a/lager/util.hpp
+++ b/lager/util.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <zug/detail/copy_traits.hpp>
 #include <zug/util.hpp>
 
 #include <functional>
@@ -46,7 +47,7 @@ struct visitor : Ts...
 //! @} group: util
 
 template <class... Ts>
-visitor(Ts...)->visitor<Ts...>;
+visitor(Ts...) -> visitor<Ts...>;
 
 namespace detail {
 
@@ -66,19 +67,91 @@ struct matcher : TupleT
 };
 
 template <typename T>
-matcher(T)->matcher<T>;
+matcher(T) -> matcher<T>;
+
+template <typename... Ts>
+decltype(auto) as_variant(std::variant<Ts...> const& x)
+{
+    return x;
+}
 
 } // namespace detail
 
+//! @defgroup util
+//! @{
+
+/*!
+ * Metafunction that returns the variant type that @a T is convertible to.
+ */
+template <typename T>
+using get_variant_t =
+    std::decay_t<decltype(detail::as_variant(std::declval<T>()))>;
+
+/*!
+ * Metafunction that returns whether @a T is `std::variant` or is convertible to
+ * `std::variant`.
+ */
+template <typename T, typename Enable = void>
+struct is_variant : std::false_type
+{};
+
+template <typename T>
+struct is_variant<T, decltype((void) detail::as_variant(std::declval<T>()))>
+    : std::true_type
+{};
+
+//! Alias for @a is_variant
+template <typename T>
+constexpr bool is_variant_v = is_variant<T>::value;
+
+/*!
+ * This forwards @a v so that if @a v is convertible to `std::variant`, the
+ * value is forwarded as a variant.
+ */
+template <typename T>
+auto forward_variant(typename std::remove_reference<T>::type& v) noexcept
+    -> std::enable_if_t<is_variant_v<T>,
+                        zug::detail::copy_decay_t<T, get_variant_t<T>>&&>
+{
+    return std::forward<T>(v);
+}
+
+template <typename T>
+auto forward_variant(typename std::remove_reference<T>::type& v) noexcept
+    -> std::enable_if_t<!is_variant_v<T>, T&&>
+{
+    static_assert(is_variant<T>::value,
+                  "you must pass a variant to forward_variant()");
+    return std::forward<T>(v);
+}
+
+/*!
+ * Provides variant visitation in a syntactically more elegant way, as in:
+ * @code
+ *   auto v = std::variant<int, float, string>{...};
+ *   return match(v)(
+       [](int x)    { ... },
+       [](float x)  { ... },
+       [](string x) { ... },
+ *   );
+ * @endcode
+ *
+ * This also fixes also fixes visitation of variants when inheriting from the
+ * variant, which is broken in GNU libstdc++.
+ * @code
+ *   using variant_t = std::variant{...};
+ *   struct inherited_t : variant_t { using variant_t::variant_t; };
+ *
+ *   auto v = inhertited_t{};
+ *   match(v)(...); // this works!
+ * @endcode
+ */
 template <typename... Variants>
 auto match(Variants&&... vs)
 {
     return detail::matcher{
-        std::forward_as_tuple(std::forward<Variants>(vs)...)};
+        std::forward_as_tuple(forward_variant<Variants>(vs)...)};
 }
-
-//! @defgroup util
-//! @{
 
 //! Function that takes any argument and does nothing
 ZUG_INLINE_CONSTEXPR struct noop_t

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -1,0 +1,38 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#include <catch.hpp>
+
+#include <lager/util.hpp>
+
+#include <variant>
+
+using variant_t = std::variant<int, float, std::string>;
+
+TEST_CASE("match")
+{
+    auto v = variant_t{42};
+    auto y = lager::match(v)([](int x) { return x; }, [](auto) { return 0; });
+    CHECK(y == 42);
+}
+
+struct deriv_t : variant_t
+{
+    using variant_t::variant_t;
+};
+
+TEST_CASE("match deriv")
+{
+    auto v = deriv_t{42};
+    auto y = lager::match(v)([](int x) { return x; }, [](auto) { return 0; });
+    CHECK(y == 42);
+}


### PR DESCRIPTION
One of the problems of `std::variant` is that it expands all thea lternatives in the type name.  This can lead to humongous compilation errors.  This is particularly true for the patterns encouraged by Lager, where actions are variants of variants of variants...

One solution to erase the alternatives from the type of the variant is to do something of the form:
```c++
  using variant_t = std::variant<...>;
  struct my_variant : variant_t { using variant_t::variant_t; };
```

However, `std::visit` does not work with variants of that form in some implemnetations.  [This is definitelly true for libstdc++](
https://stackoverflow.com/questions/51309467/using-stdvisit-on-a-class-inheriting-from-stdvariant-libstdc-vs-libc).

This PR works around it in lager::match itself. Also some utilities are provided that can come handy when applying the workaround when metaprograming.