### PR TITLE
Support monostate variant serialization

### DIFF
--- a/lager/extra/cereal/variant_with_name.hpp
+++ b/lager/extra/cereal/variant_with_name.hpp
@@ -84,4 +84,8 @@ inline void CEREAL_LOAD_FUNCTION_NAME(Archive& ar, std::variant<Ts...>& variant)
     detail::load_variant<0, variant_t, Ts...>(ar, target, variant);
 }
 
+//! Serializing a std::monostate
+template <class Archive>
+void CEREAL_SERIALIZE_FUNCTION_NAME( Archive &, std::monostate const & ) {}
+
 } // namespace cereal

--- a/test/cereal/variant_with_name.cpp
+++ b/test/cereal/variant_with_name.cpp
@@ -1,0 +1,22 @@
+//
+// lager - library for functional interactive c++ programs
+// Copyright (C) 2017 Juan Pedro Bolivar Puente
+//
+// This file is part of lager.
+//
+// lager is free software: you can redistribute it and/or modify
+// it under the terms of the MIT License, as detailed in the LICENSE
+// file located at the root of this source code distribution,
+// or here: <https://github.com/arximboldi/lager/blob/master/LICENSE>
+//
+
+#include "cerealize.hpp"
+#include <catch.hpp>
+#include <lager/extra/cereal/variant_with_name.hpp>
+
+TEST_CASE("basic")
+{
+    auto x = std::variant<int, std::monostate, float>{std::monostate{}};
+    auto y = cerealize(x);
+    CHECK(x == y);
+}


### PR DESCRIPTION
As added later in cereal/types/variant.hpp (see e6dc5d37)