### PR TITLE
Test implementation of deferred calculation of the 'get()' part of le…

### DIFF
--- a/lager/detail/lens_nodes.hpp
+++ b/lager/detail/lens_nodes.hpp
@@ -36,18 +36,20 @@ class lens_reader_node;
 template <typename Lens, typename... Parents, template <class> class Base>
 class lens_reader_node<Lens, zug::meta::pack<Parents...>, Base>
     : public inner_node<
-          std::decay_t<decltype(view(
-              std::declval<Lens>(),
-              zug::tuplify(std::declval<zug::meta::value_t<Parents>>()...)))>,
+          std::decay_t<
+              remove_deferred_t<
+                  decltype(view(std::declval<Lens>(),
+                                zug::tuplify(std::declval<zug::meta::value_t<Parents>>()...)))>>,
           zug::meta::pack<Parents...>,
           Base>
 {
     using base_t = inner_node<
-        std::decay_t<decltype(view(
-            std::declval<Lens>(),
-            zug::tuplify(std::declval<zug::meta::value_t<Parents>>()...)))>,
-        zug::meta::pack<Parents...>,
-        Base>;
+    std::decay_t<
+        remove_deferred_t<
+            decltype(view(std::declval<Lens>(),
+                          zug::tuplify(std::declval<zug::meta::value_t<Parents>>()...)))>>,
+    zug::meta::pack<Parents...>,
+    Base>;
 
 protected:
     Lens lens_;
@@ -55,14 +57,14 @@ protected:
 public:
     template <typename Lens2, typename ParentsTuple>
     lens_reader_node(Lens2&& l, ParentsTuple&& parents)
-        : base_t{view(l, current_from(parents)),
+        : base_t{static_cast<typename base_t::value_type>(view(l, current_from(parents))),
                  std::forward<ParentsTuple>(parents)}
         , lens_{std::forward<Lens2>(l)}
     {}
 
     void recompute() final
     {
-        this->push_down(view(lens_, current_from(this->parents())));
+        this->push_down(static_cast<typename base_t::value_type>(view(lens_, current_from(this->parents()))));
     }
 };
 

--- a/lager/lenses.hpp
+++ b/lager/lenses.hpp
@@ -107,9 +107,10 @@ auto getset(Getter&& getter, Setter&& setter)
 {
     return zug::comp([=](auto&& f) {
         return [&, f = LAGER_FWD(f)](auto&& p) {
-            return f(getter(std::forward<decltype(p)>(p)))([&](auto&& x) {
-                return setter(std::forward<decltype(p)>(p),
-                              std::forward<decltype(x)>(x));
+            return f(lager::make_deferred(getter, std::forward<decltype(p)>(p)))
+                    ([&](auto&& x) {
+                         return setter(std::forward<decltype(p)>(p),
+                             std::forward<decltype(x)>(x));
             });
         };
     });

--- a/lager/util.hpp
+++ b/lager/util.hpp
@@ -115,4 +115,40 @@ const T& unwrap(const T& x)
     return x;
 }
 
+/*!
+ * Defers calculation of the value of the function till type
+ * conversion is actually requested
+ */
+
+template <typename Func, typename P, typename X>
+struct deferred
+{
+    Func &&func;
+    P &&p;
+
+    operator X() {
+        return LAGER_FWD(std::forward<Func>(func)(std::forward<P>(p)));
+    }
+};
+
+template <typename Func, typename P, typename X = decltype(std::declval<Func>()(std::declval<P>()))>
+auto make_deferred(Func&& f, P&& p) -> deferred<Func, P, X>
+{
+    return {std::forward<Func>(f), std::forward<P>(p)};
+}
+
+template <typename T>
+struct remove_deferred {
+    using type = T;
+};
+
+template <typename Func, typename P, typename X>
+struct remove_deferred<deferred<Func, P, X>> {
+    using type = X;
+};
+
+template <typename T>
+using remove_deferred_t = typename remove_deferred<T>::type;
+
+
 } // namespace lager


### PR DESCRIPTION
…nses

WARNING: this patch is only a proof of concept. It breaks a lot of
         unittests and I don't know how to fix them.

The perpose of this patch is twofold:

1) Avoid execution of the 'get()' part fo the lens when only set is
   requested
2) Avoid double expiring of the object when 'get()' part of the lens
   accepts the "whole" object as a non-reference