### PR TITLE
WIP: Fix extra call to 'getter' in 'lenses::getset' on set call

### DIFF
--- a/lager/lenses.hpp
+++ b/lager/lenses.hpp
@@ -63,6 +63,37 @@ struct identity_functor
             std::forward<Fn>(f)(std::forward<T>(value)));
     }
 };
+
+template <typename Part>
+struct identity_functor_skip_first
+{
+    auto operator() (auto&&) const {
+        return make_identity_functor(part);
+    }
+
+    Part &part;
+};
+
+template <typename T>
+auto make_identity_functor_skip_first(T&& x) -> identity_functor_skip_first<std::remove_reference_t<T>>
+{
+    return {std::forward<T>(x)};
+}
+
+template <typename Func, typename Getter, typename Whole>
+auto call_getter_or_skip(const Func& func, Getter&& getter, Whole&& whole) {
+    return func(LAGER_FWD(getter)(LAGER_FWD(whole)));
+}
+
+template <typename Getter, typename Part, typename Whole>
+auto call_getter_or_skip(const identity_functor_skip_first<Part>& func, Getter&&, Whole&&) {
+    /**
+     * When set() call is being executed, we should not execute the setter,
+     * the value will be dropped later anyway
+     */
+    return func(*static_cast<Part*>(nullptr));
+}
+
 } // namespace detail
 
 //! @defgroup lenses-api
@@ -80,7 +111,7 @@ decltype(auto) view(LensT&& lens, T&& x)
 template <typename LensT, typename T, typename U>
 decltype(auto) set(LensT&& lens, T&& x, U&& v)
 {
-    return lens([&v](auto&&) { return detail::make_identity_functor(v); })(
+    return lens(detail::make_identity_functor_skip_first(v)) (
                std::forward<T>(x))
         .value;
 }
@@ -107,9 +138,8 @@ auto getset(Getter&& getter, Setter&& setter)
 {
     return zug::comp([=](auto&& f) {
         return [&, f = LAGER_FWD(f)](auto&& p) {
-            return f(getter(std::forward<decltype(p)>(p)))([&](auto&& x) {
-                return setter(std::forward<decltype(p)>(p),
-                              std::forward<decltype(x)>(x));
+            return detail::call_getter_or_skip(f, getter, LAGER_FWD(p))([&](auto&& x) {
+                return setter(LAGER_FWD(p), LAGER_FWD(x));
             });
         };
     });


### PR DESCRIPTION
Basically, we shouldn't calculate the getter when we know that the value will be dropped.

The patch partially fixes #160, because now the getter is not called at all during the set operation. But the double-move can still happen when both, getter and setter calls are performed.

WARNING:
---------------
I'm not really sure about the correctness of the patch. Please check. There is some weirdness with the constness of the last argument of `call_getter_or_skip`. 

Otherwise, the patch compiles find and the unittest passes.
