### PR TITLE
Implement watchable_base::unbind()

### DIFF
--- a/lager/watch.hpp
+++ b/lager/watch.hpp
@@ -100,6 +100,12 @@ public:
     }
 
     void nudge() { base_t::operator()(node()->last()); }
+
+    void unbind()
+    {
+        conns_.clear();
+        base_t::unlink();
+    }
 };
 
 /*!

--- a/test/watchers.cpp
+++ b/test/watchers.cpp
@@ -66,3 +66,56 @@ TEST_CASE("bind")
     CHECK(called == 1);
     CHECK(value == 42);
 }
+
+TEST_CASE("assignment doesn't change signal bindings")
+{
+    lager::state<int, lager::automatic_tag> data1;
+    lager::state<int, lager::automatic_tag> data2;
+
+    lager::reader<int> reader = data1;
+
+    int bind1_times_called = 0;
+    reader.bind([&bind1_times_called] (int i) { bind1_times_called++;});
+    CHECK(bind1_times_called == 1);
+
+    data1.set(42);
+    CHECK(bind1_times_called == 2);
+
+    reader = data2;
+
+    // data1 is not connected anymore!
+    data1.set(43);
+    CHECK(bind1_times_called == 2);
+
+    // but data2 is!
+    data2.set(44);
+    CHECK(bind1_times_called == 3);
+
+    int bind2_times_called = 0;
+    reader.bind([&bind2_times_called] (int i) { bind2_times_called++;});
+    CHECK(bind2_times_called == 1);
+
+    data2.set(46);
+    CHECK(bind1_times_called == 4);
+    CHECK(bind2_times_called == 2);
+
+}
+
+TEST_CASE("reader::unbind")
+{
+    lager::state<int, lager::automatic_tag> data1;
+
+    lager::reader<int> reader = data1;
+
+    int bind1_times_called = 0;
+    reader.bind([&bind1_times_called] (int i) { bind1_times_called++;});
+    CHECK(bind1_times_called == 1);
+
+    data1.set(42);
+    CHECK(bind1_times_called == 2);
+
+    reader.unbind();
+
+    data1.set(43);
+    CHECK(bind1_times_called == 2);
+}


### PR DESCRIPTION
It turned out that there was no way to unbind anything from a reader after once bound. Assignment operator keeps all the binding untouched (which looks a bit strange, but "by design"), so we need a separate method to unbind everything when needed.
