### PR TITLE
cmake: fix finding cursesw

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,7 +15,7 @@ add_dependencies(examples counter-std)
 # ncurses examples
 # ================
 
-set(CMAKE_CURSES_NEED_WIDE true)
+set(CURSES_NEED_WIDE true)
 
 find_package(Curses)
 


### PR DESCRIPTION
The right variable for requesting the unicode version of curses is `CURSES_NEED_WIDE`, not `CMAKE_CURSES_NEED_WIDE` [1].

[1] https://cmake.org/cmake/help/latest/module/FindCurses.html