### PR TITLE
Include <cstdint> for std::uint32_t

### DIFF
--- a/lager/event_loop/sdl.hpp
+++ b/lager/event_loop/sdl.hpp
@@ -25,6 +25,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 
 #if __EMSCRIPTEN__
 #include <emscripten.h>


### PR DESCRIPTION
This way it builds also with GCC 13, which no more implicitly includes `<cstdint>` from other headers included in this file.