### PR TITLE
Fix build of http_debug_server with boost >= 1.80

### DIFF
--- a/lager/debug/http_server.hpp
+++ b/lager/debug/http_server.hpp
@@ -284,7 +284,7 @@ struct http_debug_server_impl
                        auto m = model_.load();
                        auto s = std::ostringstream{};
                        {
-                           auto target = req.target().to_string();
+                           auto target = static_cast<std::string>(req.target());
                            auto cursor =
                                std::stoul(target.substr(target.rfind('/') + 1));
                            auto result = m->lookup(cursor);
@@ -300,7 +300,7 @@ struct http_debug_server_impl
             .route(beast::http::verb::post,
                    "/api/goto/[0-9]+",
                    [this](auto&& req) {
-                       auto target = req.target().to_string();
+                       auto target = static_cast<std::string>(req.target());
                        auto cursor =
                            std::stoul(target.substr(target.rfind('/') + 1));
                        context_.dispatch(
@@ -337,7 +337,7 @@ struct http_debug_server_impl
                    })
 
             .route(beast::http::verb::get, "/?.*", [this](auto&& req) {
-                auto req_path = req.target().to_string();
+                auto req_path = static_cast<std::string>(req.target());
                 auto rel_path =
                     req_path == "/" ? "/gui/index.html" : "/gui/" + req_path;
                 auto full_path = resources_path() + rel_path;


### PR DESCRIPTION
Boost Beast 1.80 switches from `boost::string_view` to `boost::core::string_view` [1][2], and thus the `to_string()` method to convert to `std::string` is not available anymore.

Both the old and the new `string_view` types used support converting to `std::string` via operator, hence switch to a `static_cast` to do the conversion. This supports building with all the versions of boost.

[1] https://www.boost.org/doc/libs/release/libs/beast/doc/html/beast/release_notes.html
[2] https://github.com/boostorg/beast/issues/2417