### PR TITLE
Add an event loop that uses a lock-free queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,16 @@ endif()
 if(lager_BUILD_TESTS)
   find_package(Catch2 REQUIRED)
 
+  set(concurrentqueue_INCLUDE_DIR "$ENV{CONCURRENTQUEUE_INCLUDE_DIR}")
+  if ("${concurrentqueue_INCLUDE_DIR}" STREQUAL "")
+    message(WARNING "Could not find concurrentqueue")
+  endif()
+
   add_library(lager-dev INTERFACE)
   target_include_directories(lager-dev SYSTEM INTERFACE
     ${lager_SOURCE_DIR}
     ${Boost_INCLUDE_DIR}
+    ${concurrentqueue_INCLUDE_DIR}
   )
   target_link_libraries(lager-dev INTERFACE lager
     ${Boost_LIBRARIES}

--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     boost
     deps.cereal
+    deps.concurrentqueue
     deps.immer
     deps.zug
   ];

--- a/lager/event_loop/lock_free_queue.hpp
+++ b/lager/event_loop/lock_free_queue.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <lager/config.hpp>
+
+#include <cassert>
+#include <functional>
+#include <stdexcept>
+#include <thread>
+
+#include <moodycamel/concurrentqueue.h>
+
+namespace lager {
+
+struct lock_free_queue_event_loop
+{
+    using event_fn = std::function<void()>;
+
+    void post(event_fn ev) { shared_queue_.enqueue(ev); }
+
+    void finish() { LAGER_THROW(std::logic_error{"not implemented!"}); }
+    void pause() { LAGER_THROW(std::logic_error{"not implemented!"}); }
+    void resume() { LAGER_THROW(std::logic_error{"not implemented!"}); }
+    template <typename Fn>
+    void async(Fn&& fn)
+    {
+        LAGER_THROW(std::logic_error{"not implemented!"});
+    }
+
+    // If there is an exception, the step() function needs to be re-run for the
+    // queue to be fully processed.
+    void step()
+    {
+        assert(thread_id_ == std::this_thread::get_id());
+        event_fn ev;
+        while (shared_queue_.try_dequeue(ev)) {
+            std::move(ev)();
+        }
+    }
+
+    void adopt()
+    {
+        assert(shared_queue_.size_approx() == 0);
+        thread_id_ = std::this_thread::get_id();
+    }
+
+private:
+    std::thread::id thread_id_ = std::this_thread::get_id();
+    moodycamel::ConcurrentQueue<event_fn> shared_queue_;
+};
+
+struct with_lock_free_queue_event_loop
+{
+    std::reference_wrapper<lock_free_queue_event_loop> loop;
+
+    template <typename Fn>
+    void async(Fn&& fn)
+    {
+        loop.get().async(std::forward<Fn>(fn));
+    }
+    template <typename Fn>
+    void post(Fn&& fn)
+    {
+        loop.get().post(std::forward<Fn>(fn));
+    }
+    void finish() { loop.get().finish(); }
+    void pause() { loop.get().pause(); }
+    void resume() { loop.get().resume(); }
+};
+
+} // namespace lager

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -91,4 +91,23 @@ rec {
       license = licenses.lgpl3;
     };
   };
+
+  concurrentqueue = stdenv.mkDerivation rec {
+    name = "concurrentqueue-${version}";
+    version = "git-${commit}";
+    commit = "6ffee0e75e8f677c5fd8280dfe544c3fcb325f45";
+    src = fetchFromGitHub {
+      owner = "cameron314";
+      repo = "concurrentqueue";
+      rev = "v1.0.4";
+      sha256 = "MkhlDme6ZwKPuRINhfpv7cxliI2GU3RmTfC6O0ke/IQ=";
+    };
+    nativeBuildInputs = [ cmake ];
+    meta = with lib; {
+      description = "Lock-free queue library";
+      license = licenses.bsd1;
+    };
+  };
+
+
 }

--- a/shell.nix
+++ b/shell.nix
@@ -48,6 +48,7 @@ theStdenv.mkDerivation rec {
     deps.immer
     deps.zug
     deps.imgui
+    deps.concurrentqueue
     SDL2
     SDL2_ttf
     qt.qtbase
@@ -85,5 +86,6 @@ theStdenv.mkDerivation rec {
     export QT_QPA_PLATFORM_PLUGIN_PATH=${qt.qtbase}/lib/qt-${qtver}/plugins
     export IMGUI_SOURCE_DIR=${deps.imgui}
     export EM_CACHE=`mktemp -d`
+    export CONCURRENTQUEUE_INCLUDE_DIR="${deps.concurrentqueue}/include/concurrentqueue"
   '';
 }

--- a/test/event_loop/lock_free_queue.cpp
+++ b/test/event_loop/lock_free_queue.cpp
@@ -1,0 +1,56 @@
+#include <catch2/catch.hpp>
+
+#include <lager/event_loop/lock_free_queue.hpp>
+#include <lager/store.hpp>
+
+#include "example/counter/counter.hpp"
+
+TEST_CASE("basic")
+{
+    auto queue = lager::lock_free_queue_event_loop{};
+    auto store = lager::make_store<counter::action>(
+        counter::model{}, lager::with_lock_free_queue_event_loop{queue});
+
+    store.dispatch(counter::increment_action{});
+    CHECK(store->value == 0);
+
+    queue.step();
+    CHECK(store->value == 1);
+}
+
+TEST_CASE("threads")
+{
+    auto queue = lager::lock_free_queue_event_loop{};
+    auto store = lager::make_store<counter::action>(
+        counter::model{}, lager::with_lock_free_queue_event_loop{queue});
+    auto threads = std::vector<std::thread>{};
+    threads.reserve(100);
+
+    for (auto i = 0; i < 100; ++i) {
+        store.dispatch(counter::increment_action{});
+        threads.push_back(
+            std::thread([&] { store.dispatch(counter::increment_action{}); }));
+    }
+    CHECK(store->value == 0);
+
+    for (auto&& t : threads)
+        t.join();
+    queue.step();
+
+    CHECK(store->value == 200);
+}
+
+TEST_CASE("exception")
+{
+    auto called = 0;
+    auto loop   = lager::lock_free_queue_event_loop{};
+
+    loop.post([&] { throw std::runtime_error{"noo!"}; });
+    loop.post([&] { ++called; });
+
+    CHECK_THROWS(loop.step());
+    CHECK(called == 0);
+
+    loop.step();
+    CHECK(called == 1);
+}


### PR DESCRIPTION
Hey! I'm considering using lager in a VST plugin where locking a mutex from the audio processing thread can be problematic. Using the `lock_free_queue_event_loop` proposed in this PR would allow thread-safe `context::dispatch()` calls without locking a mutex by relying on [moodycamel::concurrentqueue](https://github.com/cameron314/concurrentqueue) to shuttle event functions between threads in a lock-free manner.

Alternatively, I could shuttle actions over to the main thread to be dispatched in client code, but being able to call `dispatch()` safely from any thread seemed a bit more ergonomic. Curious to hear what you think. Thanks!