### PR TITLE
allow forward declaration of values held by reader

### DIFF
--- a/lager/reader.hpp
+++ b/lager/reader.hpp
@@ -125,9 +125,9 @@ public:
  * Provides access to reading values of type `T`.
  */
 template <typename T>
-class reader : public reader_base<detail::reader_node<T>>
+class reader : public reader_base<detail::observable_reader_node<T>>
 {
-    using base_t = reader_base<detail::reader_node<T>>;
+    using base_t = reader_base<detail::observable_reader_node<T>>;
 
 public:
     using base_t::base_t;

--- a/test/cursor.cpp
+++ b/test/cursor.cpp
@@ -226,3 +226,26 @@ TEST_CASE("lenses over with expression")
     CHECK(person_data->name == "new name");
     CHECK(name.get() == "new name");
 }
+
+struct Foo;
+struct Bar
+{
+    lager::reader<Foo> foo;
+    reader<Foo> get_reader() const;
+};
+struct Baz
+{
+    Baz(const lager::reader<Foo>& r);
+};
+TEST_CASE("forward declare a reader value")
+{
+    auto bar = Bar();
+    auto baz = Baz(bar.get_reader());
+}
+struct Foo
+{};
+lager::reader<Foo> Bar::get_reader() const
+{
+    return lager::make_constant(Foo());
+}
+Baz::Baz(const lager::reader<Foo>&) {}


### PR DESCRIPTION
This commit enables the forward declaration of a type held by a reader without any new memory allocation or virtual methods. This is achieved by creating a new class  -- observable_reader_node -- in the reader_node hierarchy which acts as a view for the type held by reader_node.

Performance Impact

Ad-hoc benchmarks (i.e. not in commit) were performed with nanobench. (https://nanobench.ankerl.com/index.html)

Compared to baseline, the impact on a reader get method was non-existent. The same was true for map. The impact on watch seemingly ranged from indiscernible to rather small, i.e. in the order of 0.5-1.5%, although why there even is an impact isn't clear.

Downsides and Limitations

1. If it matters, the protected keyword has now been introduced within the reader node class hierarchy. This is because the link method and the observers access method had to be moved in observable_reader_node to avoid virtual method declaration.
2. While the values held by a reader are now fwd declarable, those held by a cursor are not. This arguably introduces an inconsistency in the API.