### PR TITLE
fix missing virtual dtor on observable_reader_node

### DIFF
--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -131,7 +131,7 @@ struct notifying_guard_t
  * Interface for nodes capable of notifying observers.
  */
 template <typename T>
-class observable_reader_node
+class observable_reader_node : public reader_node_base
 {
 public:
     using value_type  = T;
@@ -186,9 +186,7 @@ private:
  * functionality for setting values and propagating them to children.
  */
 template <typename T>
-class reader_node
-    : public reader_node_base
-    , public observable_reader_node<T>
+class reader_node : public observable_reader_node<T>
 {
 public:
     using value_type  = typename observable_reader_node<T>::value_type;


### PR DESCRIPTION
This commit fixes an issue where the observable_reader_node, which serve as a base class for reader_node, didn't have a virtual dtor.

This was made easier to miss in virtue of observable_reader_node not having any virtual method.

By having observable_reader_node derive from reader_node_base, we effectively fix the issue and by removing multiple inheritance. observable_reader_node now inherits its virtual dtor from reader_node_base.