### PR TITLE
revert to index based notify loop

### DIFF
--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -235,8 +235,9 @@ public:
             bool garbage = false;
 
             this->observers()(last_);
-            for (auto& wchild : this->children()) {
-                if (auto child = wchild.lock()) {
+            const auto& children = this->children();
+            for (size_t i = 0, size = children.size(); i < size; ++i) {
+                if (auto child = children[i].lock()) {
                     child->notify();
                 } else {
                     garbage = true;


### PR DESCRIPTION
This fixes an issue in which calls to link occurring during notification would invalidate the iterators of the structured for loop. Calling link as a result of a reader<T>::watch callback can occur quite naturally.

By using the size of the children vector at the point at which the for loop is initiated, and by using the [] operator in order to access the children within the vector, the issue is avoided.