### PR TITLE
Add a comment to explain why ranged-for cannot be used

### DIFF
--- a/lager/detail/nodes.hpp
+++ b/lager/detail/nodes.hpp
@@ -235,6 +235,10 @@ public:
             bool garbage = false;
 
             this->observers()(last_);
+            // We cannot use ranged-for here because children might
+            // change as a result of notify(). This can invalidate
+            // the iterators on children, causing undefined behaviors.
+            // See also https://github.com/arximboldi/lager/pull/212
             const auto& children = this->children();
             for (size_t i = 0, size = children.size(); i < size; ++i) {
                 if (auto child = children[i].lock()) {


### PR DESCRIPTION
I spent two whole days wondering why my application crashes all of a sudden. Hope this can prevent someone changing it back to ranged-for in the future, as it is really tempting to do so.