### PR TITLE
allow json to have missing NVP 

### DIFF
--- a/lager/extra/derive/cereal.hpp
+++ b/lager/extra/derive/cereal.hpp
@@ -25,8 +25,18 @@
     cereal::make_nvp(BOOST_PP_STRINGIZE(elem__), x.elem__)
 
 #define LAGER_DERIVE_IMPL_CEREAL_MEMBERS_NON_EMPTY__(r__, members__)           \
-    ar(BOOST_PP_SEQ_FOR_EACH_I_R(                                              \
-        r__, LAGER_DERIVE_IMPL_CEREAL_ITER__, _, members__));
+    try {                                                                      \
+        ar(BOOST_PP_SEQ_FOR_EACH_I_R(                                          \
+            r__, LAGER_DERIVE_IMPL_CEREAL_ITER__, *, members__));              \
+    } catch (const cereal::Exception&) {                                       \
+        /* Default construct all members */                                    \
+        BOOST_PP_SEQ_FOR_EACH_R(                                               \
+            r__, LAGER_DERIVE_IMPL_DEFAULT__, *, members__);                   \
+    }
+
+// Helper macro to default construct each member
+#define LAGER_DERIVE_IMPL_DEFAULT__(r__, data__, elem__)                       \
+    x.elem__ = decltype(x.elem__){};
 
 #define LAGER_DERIVE_IMPL_CEREAL_MEMBERS_EMPTY__(r__, members__)
 


### PR DESCRIPTION
Using cereal allows common structs to be serdes using json. 
Missing fields in the json cause an exception on load. This slows down iteration in use-cases where the structs are changing versions. This branch silently falls back to a default constructed field if it is not able to be loaded.

This silent healing may not be appreciated in some use-cases. Perhaps all this should be hidden behind a config?
