### PR TITLE
#225 | Bugfix | No notification on filtered cursor default value update

### DIFF
--- a/test/cursor.cpp
+++ b/test/cursor.cpp
@@ -268,7 +268,6 @@ TEST_CASE("watch filtered xform of optional ints | update default value")
     state.set(0);
     commit(state);
     REQUIRE(state.get() == 0);
-    // bug! not notified of value change
     CHECK(called == 1);
 }
 
@@ -287,6 +286,5 @@ TEST_CASE("watch filtered xform of optional strings | update default value")
     state.set("");
     commit(state);
     REQUIRE(state.get() == "");
-    // bug! not notified of value change
     CHECK(called == 1);
 }


### PR DESCRIPTION
This patch addresses [issue #255](https://github.com/arximboldi/lager/issues/225).

The issue arrises because, for filtered, transformed nodes (like in the test example) an inner node is created with a default initialised value. However, if this node doesn't get processed because it get's filtered out by the parent then, the next time it would receive a true value it's possible for that value to be erroneously ignored when it's the default value of the node type.

The fix here is to track whether a node has already been "pushed down" and for inner nodes to override the logic from the base node and push down even if the value didn't change. 

I hope that this change is correct and doesn't cause any regressions. The full test suite passes with the patch. Please shout out if I've overlooked any cases!