### PR TITLE
Switch from boost::asio::io_service to io_context

### DIFF
--- a/example/counter/ncurses/main.cpp
+++ b/example/counter/ncurses/main.cpp
@@ -58,7 +58,7 @@ void draw(const counter::model& c)
 
 int main(int argc, const char** argv)
 {
-    auto serv = boost::asio::io_service{};
+    auto serv = boost::asio::io_context{};
     auto term = ncurses::terminal{serv};
     ::init_pair(1, COLOR_WHITE, COLOR_GREEN);
     ::init_pair(2, COLOR_WHITE, COLOR_RED);

--- a/example/counter/ncurses/terminal.cpp
+++ b/example/counter/ncurses/terminal.cpp
@@ -21,7 +21,7 @@ using namespace std::string_literals;
 
 namespace ncurses {
 
-terminal::terminal(boost::asio::io_service& serv)
+terminal::terminal(boost::asio::io_context& serv)
     : win_{[] {
         std::locale::global(std::locale(""));
         ::setlocale(LC_ALL, "");

--- a/example/counter/ncurses/terminal.hpp
+++ b/example/counter/ncurses/terminal.hpp
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/signal_set.hpp>
 
@@ -59,7 +59,7 @@ struct terminal
 {
     using event_handler = std::function<void(event)>;
 
-    terminal(boost::asio::io_service& serv);
+    terminal(boost::asio::io_context& serv);
 
     coord size();
 


### PR DESCRIPTION
`boost::asio::io_context` has been available for many asio/boost versions, and `io_service` is a deprecated alias for it.

Since `io_service` and its bits (e.g. `io_context.hpp`) are being removed, switch to the proper name. There should be no behaviour changes.