### PR TITLE
Make lambda in effect mutable

### DIFF
--- a/lager/effect.hpp
+++ b/lager/effect.hpp
@@ -63,7 +63,7 @@ lager::effect<lager::actions<...>, ...> " //
             int> = 0>
     effect(Fn&& fn)
         : base_t{[fn = std::forward<Fn>(fn)](auto&& ctx) mutable -> future {
-            std::move(fn)(LAGER_FWD(ctx))
+            std::move(fn)(LAGER_FWD(ctx));
             return {};
         }}
     {}


### PR DESCRIPTION
This enables doing things like:

```
ReducerResult reduce(Model model, const action::DatabaseDepsInitialized&)
{
    auto modelCopy = model;
    return { std::move(model), [modelCopy = std::move(modelCopy)](const Context& ctx) mutable {
                 auto& deps = lager::get<Dependencies&>(ctx);
                
                 // use deps to update model from newly initialized db
                 // etc.

                ctx.dispatch(db::action::DbInitialized { std::move(modelCopy) });
            } };
}

// or something like:

ReducerResult reduce(Model model,action::UserDownloadsRequested&& action)
{
    return { std::move(model), [downloadIds = std::move(action.downloadIds)](const Context& ctx) mutable {
                 auto& deps = lager::get<Dependencies&>(ctx);
                 deps.performDownloadOnBackgroundThread(std::move(downloadIds));
            } };
}




```

without making the effect lambda mutable, I get:

lager/effect.hpp:66:13: error: no matching function for call to object of type '(lambda at init_reducers.cpp:10:18) const'
   66 |             fn(ctx);
   
   ...

init_reducers.cpp:10:18: note: candidate function not viable: 'this' argument has type '(lambda at init_reducers.cpp:10:18) const', but method is not marked const
   10 |     return { {}, [m = std::move(model)](const Context& ctx) mutable { 