### PR TITLE
Bugfix | MSVC warning | Fewer args than expected to macro function call

### DIFF
--- a/lager/detail/xform_nodes.hpp
+++ b/lager/detail/xform_nodes.hpp
@@ -67,7 +67,7 @@ initial_value<ValueT> get_initial_value(Xform&& xform, const std::tuple<ParentPt
         if constexpr (std::is_default_constructible<ValueT>::value) {
             return {ValueT{}, true};
         } else {
-            LAGER_THROW();
+            LAGER_RETHROW;
         }
     }
 };


### PR DESCRIPTION
Clang and GCC will allow macro function calls to omit arguments, however [MSVC will emit a warning by default](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4003?view=msvc-170).

This small patch patch introduces no logical change, swapping the no-args call to `LAGER_THROW()` with its equivalent counterpart `LAGER_RETHROW`.